### PR TITLE
Endre brukeroppslag til å være en post

### DIFF
--- a/src/main/kotlin/no/nav/persondataapi/rest/OppslagBrukerController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/OppslagBrukerController.kt
@@ -1,6 +1,7 @@
 package no.nav.persondataapi.rest
 
 import kotlinx.coroutines.runBlocking
+import no.nav.persondataapi.aareg.client.Ident
 import no.nav.persondataapi.domain.GrunnlagsData
 import no.nav.persondataapi.rest.domain.OppslagBrukerRespons
 import no.nav.persondataapi.service.OppslagService
@@ -12,6 +13,7 @@ import no.nav.security.token.support.core.context.TokenValidationContextHolder
 
 
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RestController
 
@@ -24,12 +26,12 @@ class OppslagBrukerController(
     private val mappingService: ResponsMappingService
 ) {
 
-    @GetMapping("/oppslag-bruker")
+    @PostMapping("/oppslag-bruker")
     @Protected
-    fun userInfo(@RequestHeader("fnr") fnr: String): OppslagBrukerRespons {
+    fun userInfo(dto: OppslagBrukerRequest): OppslagBrukerRespons {
         return runBlocking {
 
-            val grunnlag = oppslagService.hentGrunnlagsData(fnr)
+            val grunnlag = oppslagService.hentGrunnlagsData(dto.fnr)
             mappingService.mapToMOppslagBrukerResponse(grunnlag)
         }
     }
@@ -44,3 +46,5 @@ class OppslagBrukerController(
         }
     }
 }
+
+data class OppslagBrukerRequest(val fnr: String)


### PR DESCRIPTION
Selv i backenden er det ikke greit å ha fødselsnummer i URLen. Denne PRen endrer brukeroppslaget til en POST, med en enkel DTO.