### PR TITLE
GitHub actions for deployment

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -1,12 +1,11 @@
-name: Build & Deploy
+name: Deploy release til prod
 permissions:
   contents: "read"
   id-token: "write"
   packages: "write"
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 
 env:
   IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}
@@ -30,25 +29,12 @@ jobs:
         id: docker-push
         with:
           team: holmes # required
-          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }} # required, but is defined as an organization variable
-          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }} # required, but is defined as an organization secret
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
     outputs:
       image: ${{ steps.docker-push.outputs.image }}
-  deploypreprod:
-    name: Deploy to Preprod
-    needs: build_and_push
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: nais/deploy/actions/deploy@v2
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: .nais/nais.yaml
-          IMAGE: ${{ needs.build_and_push.outputs.image }}
-          TELEMETRY: ${{ needs.build_and_push.outputs.telemetry }}
   deployprod:
-    name: Deploy to Prod
+    name: Deploy til Prod
     needs: build_and_push
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -1,9 +1,12 @@
-name: Build & Deploy
+name: Deploy til dev
 permissions:
   contents: "read"
   id-token: "write"
   packages: "write"
-on: [ pull_request ]
+on:
+  push:
+      branches: [ main ]
+  workflow_dispatch:
 
 env:
   IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}
@@ -32,7 +35,7 @@ jobs:
     outputs:
       image: ${{ steps.docker-push.outputs.image }}
   deploypreprod:
-    name: Deploy to Preprod
+    name: Deploy to dev
     needs: build_and_push
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-deploy-comment.yml
+++ b/.github/workflows/pr-deploy-comment.yml
@@ -1,0 +1,4 @@
+name: pr-deploy-comment.yml
+on:
+
+jobs:

--- a/.github/workflows/pr-deploy-comment.yml
+++ b/.github/workflows/pr-deploy-comment.yml
@@ -1,4 +1,46 @@
-name: pr-deploy-comment.yml
+name: Legg til deploy-knapp i PR
 on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  pull-requests: write
 
 jobs:
+  add-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Legg til deploy-knapp i PR
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const workflowId = 'deploy-to-dev.yml';
+
+            // Fetch existing comments
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+
+            // Check if we already have a deploy comment
+            const hasAlreadyAddedDeployComment = comments.data.some(comment => 
+              comment.body.includes('🚀 Deploy til dev-miljø')
+            );
+
+            if (!hasAlreadyAddedDeployComment) {
+              const comment = `## 🚀 Deploy til dev-miljø
+
+              Vil du deploye denne branchen til dev-miljøet?
+
+              [![Deploy til dev](https://img.shields.io/badge/Deploy-til_dev-blue?style=for-the-badge)](${context.payload.repository.html_url}/actions/workflows/${workflowId})
+
+              Klikk på knappen over, trykk "Run workflow", velg branchen "${context.payload.pull_request.head.ref}" og trykk på den grønne knappen.`;
+
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: comment
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ API for uthenting av persondata for Borger eller innbygger i Norge med Nav tilkn
 ## Komme i gang
 Bruker gradle wrapper, så bare klon og kjør `./gradlew build`
 
+## Deployment
+
+Applikasjonen deployes automatisk til NAIS på GCP via GitHub Actions.
+
+For deployment til dev-miljøet, kan du kjøre actionen [Deploy til dev](https://github.com/navikt/nav-persondata-api/actions/workflows/deploy-to-dev.yml) med den branchen du ønsker å deploye. `main`-branchen deployes også til dev hver gang man merger en pull request til `main`.
+
+For deployment til produksjon, lag en [ny release](https://github.com/navikt/nav-persondata-api/releases/new).
+
 ---
 
 ## Henvendelser


### PR DESCRIPTION
Denne PRen dupliserer og tilpasser noen GitHub actions fra frontend-koden, slik at man:

- Får en "deploy til dev"-kommentar på PRet ditt
- Deployer til dev når man merger til main
- Deployer til prod når man lager en release