### PR TITLE
Legg til codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @navikt/holmes


### PR DESCRIPTION
Denne PRen legger til en codeowners-fil, som refererer til teamet vårt. Det gjør at vi automatisk blir lagt til som reviewers på alle pull requests.