### PR TITLE
Lag egne endepunkter for forskjellige baksystemer

### DIFF
--- a/src/main/kotlin/no/nav/persondataapi/aareg/client/AaregClient.kt
+++ b/src/main/kotlin/no/nav/persondataapi/aareg/client/AaregClient.kt
@@ -25,7 +25,7 @@ class AaregClient(
 
     private val arbeidsforholdListType = object : TypeReference<List<Arbeidsforhold>>() {}
 
-    fun hentArbeidsForhold(fnr: String): AaregDataResultat {
+    fun hentArbeidsforhold(fnr: String): AaregDataResultat {
         return runCatching {
             val oboToken = tokenService.getServiceToken(SCOPE.AAREG_SCOPE)
 

--- a/src/main/kotlin/no/nav/persondataapi/aareg/client/AaregClient.kt
+++ b/src/main/kotlin/no/nav/persondataapi/aareg/client/AaregClient.kt
@@ -25,7 +25,7 @@ class AaregClient(
 
     private val arbeidsforholdListType = object : TypeReference<List<Arbeidsforhold>>() {}
 
-    fun hentArbeidsForhold(fnr: String, token: String): AaregDataResultat {
+    fun hentArbeidsForhold(fnr: String): AaregDataResultat {
         return runCatching {
             val oboToken = tokenService.getServiceToken(SCOPE.AAREG_SCOPE)
 

--- a/src/main/kotlin/no/nav/persondataapi/domain/DomainObjects.kt
+++ b/src/main/kotlin/no/nav/persondataapi/domain/DomainObjects.kt
@@ -61,7 +61,7 @@ data class TilgangResultat(
 
 data class PersonDataResultat(
     val data: Person?,
-    val statusCode: Int?,               // f.eks. 200, 401, 500
+    val statusCode: Int,               // f.eks. 200, 401, 500
     val errorMessage: String? = null
 )
 

--- a/src/main/kotlin/no/nav/persondataapi/ereg/client/EregClient.kt
+++ b/src/main/kotlin/no/nav/persondataapi/ereg/client/EregClient.kt
@@ -3,6 +3,7 @@ package no.nav.persondataapi.ereg.client
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 
@@ -14,6 +15,7 @@ class EregClient(
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
+    @Cacheable("organisasjon")
     fun hentOrganisasjon(orgnummer: String): EregRespons {
         val rawJson: String = try {
             webClient.get()

--- a/src/main/kotlin/no/nav/persondataapi/inntekt/client/InntektClient.kt
+++ b/src/main/kotlin/no/nav/persondataapi/inntekt/client/InntektClient.kt
@@ -28,7 +28,7 @@ class InntektClient(
     // Felles tags for denne klienten
 
 
-    fun hentInntekter(fnr: String, token:String, kontrollPeriode: KontrollPeriode = KontrollPeriode(LocalDate.now().minusYears(5),
+    fun hentInntekter(fnr: String, kontrollPeriode: KontrollPeriode = KontrollPeriode(LocalDate.now().minusYears(5),
         LocalDate.now())): InntektDataResultat {
 
         return runCatching {

--- a/src/main/kotlin/no/nav/persondataapi/pdl/client/PdlClient.kt
+++ b/src/main/kotlin/no/nav/persondataapi/pdl/client/PdlClient.kt
@@ -68,10 +68,7 @@ class PdlClient(
         )
     }
     suspend fun hentPersonv2(ident: String): PersonDataResultat {
-
-
-        val token = tokenService.getServiceToken(SCOPE.PDL_SCOPE
-        )
+        val token = tokenService.getServiceToken(SCOPE.PDL_SCOPE)
 
         val client = GraphQLWebClient(
             url = pdl_url,
@@ -106,4 +103,3 @@ class PdlClient(
         )
     }
 }
-

--- a/src/main/kotlin/no/nav/persondataapi/rest/ArbeidController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/ArbeidController.kt
@@ -21,7 +21,7 @@ class ArbeidController(
             val context = tokenValidationContextHolder.getTokenValidationContext()
             val token = context.firstValidToken?.encodedToken
                 ?: throw IllegalStateException("Fant ikke gyldig token")
-            val res = aaregClient.hentArbeidsForhold(fnr,token)
+            val res = aaregClient.hentArbeidsForhold(fnr)
             res
         }
     }

--- a/src/main/kotlin/no/nav/persondataapi/rest/ArbeidController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/ArbeidController.kt
@@ -21,7 +21,7 @@ class ArbeidController(
             val context = tokenValidationContextHolder.getTokenValidationContext()
             val token = context.firstValidToken?.encodedToken
                 ?: throw IllegalStateException("Fant ikke gyldig token")
-            val res = aaregClient.hentArbeidsForhold(fnr)
+            val res = aaregClient.hentArbeidsforhold(fnr)
             res
         }
     }

--- a/src/main/kotlin/no/nav/persondataapi/rest/UtbetalingController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/UtbetalingController.kt
@@ -11,18 +11,13 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class UtbetalingController(
-    private val tokenValidationContextHolder: TokenValidationContextHolder,
     private val utbetalingClient: UtbetalingClient
 ) {
     @GetMapping("/utbetalinger")
     @Protected
     fun hentUtbetalinger(@RequestHeader("fnr") fnr: String): UtbetalingResultat {
         return runBlocking {
-            val context = tokenValidationContextHolder.getTokenValidationContext()
-            val token = context.firstValidToken?.encodedToken
-                ?: throw IllegalStateException("Fant ikke gyldig token")
-            val res = utbetalingClient.hentUtbetalingerForAktor(fnr,token)
-            res
+            utbetalingClient.hentUtbetalingerForAktor(fnr)
         }
     }
 }

--- a/src/main/kotlin/no/nav/persondataapi/rest/UtbetalingController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/UtbetalingController.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.runBlocking
 import no.nav.persondataapi.domain.UtbetalingResultat
 import no.nav.persondataapi.utbetaling.client.UtbetalingClient
 import no.nav.security.token.support.core.api.Protected
-import no.nav.security.token.support.core.context.TokenValidationContextHolder
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RestController
@@ -17,7 +16,7 @@ class UtbetalingController(
     @Protected
     fun hentUtbetalinger(@RequestHeader("fnr") fnr: String): UtbetalingResultat {
         return runBlocking {
-            utbetalingClient.hentUtbetalingerForAktor(fnr)
+            utbetalingClient.hentUtbetalingerForBruker(fnr)
         }
     }
 }

--- a/src/main/kotlin/no/nav/persondataapi/rest/domain/OppslagBrukerRespons.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/domain/OppslagBrukerRespons.kt
@@ -58,10 +58,10 @@ data class UtenlandskAdresse(
 
 
 data class InntektInformasjon(
-    val lønnsinntekt : List<LoensDetaljer> = emptyList(),
-    val næringsinntekt : List<LoensDetaljer> = emptyList(),
-    val pensjonEllerTrygd : List<LoensDetaljer> = emptyList(),
-    val ytelseFraOffentlige : List<LoensDetaljer> = emptyList(),
+    val lønnsinntekt : List<Lønnsdetaljer> = emptyList(),
+    val næringsinntekt : List<Lønnsdetaljer> = emptyList(),
+    val pensjonEllerTrygd : List<Lønnsdetaljer> = emptyList(),
+    val ytelseFraOffentlige : List<Lønnsdetaljer> = emptyList(),
 )
 
 data class ArbeidsgiverInformasjon(
@@ -125,7 +125,7 @@ data class UtbetalingInfo(
 /*
 * Lønn fra A-Meldingen
 * */
-data class LoensDetaljer(
+data class Lønnsdetaljer(
     val arbeidsgiver: String?,
     val periode:String,
     val arbeidsforhold:String,

--- a/src/main/kotlin/no/nav/persondataapi/rest/inntektController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/inntektController.kt
@@ -11,18 +11,13 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class inntektController(
-    private val tokenValidationContextHolder: TokenValidationContextHolder,
     private val inntektClient: InntektClient
 ) {
     @GetMapping("/inntekt")
     @Protected
     fun hentInnekter(@RequestHeader("fnr") fnr: String): InntektDataResultat {
         return runBlocking {
-            val context = tokenValidationContextHolder.getTokenValidationContext()
-            val token = context.firstValidToken?.encodedToken
-                ?: throw IllegalStateException("Fant ikke gyldig token")
-            val res = inntektClient.hentInntekter(fnr,token)
-            res
+            inntektClient.hentInntekter(fnr)
         }
     }
 }

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/ArbeidsforholdController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/ArbeidsforholdController.kt
@@ -24,7 +24,7 @@ class ArbeidsforholdController(val aaregClient: AaregClient, val eregClient: Ere
             if (!brukertilgangService.harBrukerTilgangTilIdent(dto.ident)) {
                 ResponseEntity(OppslagResponseDto(error = "Ingen tilgang", data = null), HttpStatus.FORBIDDEN)
             }
-            val aaregRespons = aaregClient.hentArbeidsForhold(dto.ident)
+            val aaregRespons = aaregClient.hentArbeidsforhold(dto.ident)
 
             when (aaregRespons.statusCode) {
                 404 -> ResponseEntity(OppslagResponseDto(error = "Person ikke funnet", data = null), HttpStatus.NOT_FOUND)

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/ArbeidsforholdController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/ArbeidsforholdController.kt
@@ -29,6 +29,7 @@ class ArbeidsforholdController(val aaregClient: AaregClient, val eregClient: Ere
             when (aaregRespons.statusCode) {
                 404 -> ResponseEntity(OppslagResponseDto(error = "Person ikke funnet", data = null), HttpStatus.NOT_FOUND)
                 403 -> ResponseEntity(OppslagResponseDto(error = "Ingen tilgang", data = null), HttpStatus.FORBIDDEN)
+                500 -> ResponseEntity(OppslagResponseDto(error = "Feil i baksystem", data = null), HttpStatus.BAD_GATEWAY)
             }
 
             val alleArbeidsforhold = aaregRespons.data

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/ArbeidsforholdController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/ArbeidsforholdController.kt
@@ -21,7 +21,7 @@ class ArbeidsforholdController(val aaregClient: AaregClient, val eregClient: Ere
     @PostMapping("/arbeidsforhold")
     fun hentArbeidsforhold(@RequestBody dto: OppslagRequestDto): ResponseEntity<OppslagResponseDto<ArbeidsgiverInformasjon>> {
         return runBlocking {
-            if (!brukertilgangService.harBrukerTilgangTilIdent(dto.ident)) {
+            if (!brukertilgangService.harSaksbehandlerTilgangTilPersonIdent(dto.ident)) {
                 ResponseEntity(OppslagResponseDto(error = "Ingen tilgang", data = null), HttpStatus.FORBIDDEN)
             }
             val aaregRespons = aaregClient.hentArbeidsforhold(dto.ident)

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/ArbeidsforholdController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/ArbeidsforholdController.kt
@@ -1,0 +1,77 @@
+package no.nav.persondataapi.rest.oppslag
+
+import kotlinx.coroutines.runBlocking
+import no.nav.persondataapi.aareg.client.AaregClient
+import no.nav.persondataapi.aareg.client.hentIdenter
+import no.nav.persondataapi.ereg.client.EregClient
+import no.nav.persondataapi.ereg.client.EregRespons
+import no.nav.persondataapi.rest.domain.ArbeidsgiverInformasjon
+import no.nav.persondataapi.service.BrukertilgangService
+import no.nav.persondataapi.service.mapArbeidsforholdTilArbeidsgiverData
+import no.nav.security.token.support.core.api.Protected
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+
+@Controller("/oppslag")
+class PersonopplysningerController(val aaregClient: AaregClient, val eregClient: EregClient, val brukertilgangService: BrukertilgangService) {
+    @Protected
+    @PostMapping("/arbeidsforhold")
+    fun hentArbeidsforhold(@RequestBody dto: ArbeidsforholdRequestDto): ResponseEntity<ArbeidsforholdResponseDto> {
+        return runBlocking {
+            if (!brukertilgangService.harBrukerTilgangTilIdent(dto.ident)) {
+                ResponseEntity(PersonopplysningerResponseDto(error = "Ingen tilgang"), HttpStatus.FORBIDDEN)
+            }
+            val aaregRespons = aaregClient.hentArbeidsForhold(dto.ident)
+
+            when (aaregRespons.statusCode) {
+                404 -> ResponseEntity(PersonopplysningerResponseDto(error = "Person ikke funnet"), HttpStatus.NOT_FOUND)
+                403 -> ResponseEntity(PersonopplysningerResponseDto(error = "Ingen tilgang"), HttpStatus.FORBIDDEN)
+            }
+
+            val alleArbeidsforhold = aaregRespons.data
+
+            if (alleArbeidsforhold.isEmpty()) {
+                ResponseEntity.ok(
+                    ArbeidsforholdResponseDto(
+                        data = ArbeidsgiverInformasjon(
+                            løpendeArbeidsforhold = emptyList(), historikk = emptyList()
+                        )
+                    )
+                )
+            }
+
+            val unikeOrganisasjonsnumre: Map<String, EregRespons> = alleArbeidsforhold
+                .hentIdenter()
+                .map { it.ident }
+                .distinct()
+                .associateWith { ident -> eregClient.hentOrganisasjon(ident) }
+
+
+            val løpendeArbeidsforhold = alleArbeidsforhold.filter { it.ansettelsesperiode.sluttdato == null }.map { arbeidsforhold ->
+                mapArbeidsforholdTilArbeidsgiverData(arbeidsforhold, unikeOrganisasjonsnumre)
+            }
+            val historiskeArbeidsforhold = alleArbeidsforhold.filter { it.ansettelsesperiode.sluttdato != null }.map { arbeidsforhold ->
+                mapArbeidsforholdTilArbeidsgiverData(arbeidsforhold, unikeOrganisasjonsnumre)
+            }
+
+
+            ResponseEntity.ok(
+                ArbeidsforholdResponseDto(
+                    data = ArbeidsgiverInformasjon(
+                        løpendeArbeidsforhold, historiskeArbeidsforhold
+                    )
+                )
+            )
+
+        }
+    }
+}
+
+data class ArbeidsforholdRequestDto(val ident: String)
+data class ArbeidsforholdResponseDto(
+    val error: String? = null,
+    val data: ArbeidsgiverInformasjon,
+)

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/ArbeidsforholdController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/ArbeidsforholdController.kt
@@ -16,26 +16,26 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 
 @Controller("/oppslag")
-class PersonopplysningerController(val aaregClient: AaregClient, val eregClient: EregClient, val brukertilgangService: BrukertilgangService) {
+class ArbeidsforholdController(val aaregClient: AaregClient, val eregClient: EregClient, val brukertilgangService: BrukertilgangService) {
     @Protected
     @PostMapping("/arbeidsforhold")
-    fun hentArbeidsforhold(@RequestBody dto: ArbeidsforholdRequestDto): ResponseEntity<ArbeidsforholdResponseDto> {
+    fun hentArbeidsforhold(@RequestBody dto: OppslagRequestDto): ResponseEntity<OppslagResponseDto<ArbeidsgiverInformasjon>> {
         return runBlocking {
             if (!brukertilgangService.harBrukerTilgangTilIdent(dto.ident)) {
-                ResponseEntity(PersonopplysningerResponseDto(error = "Ingen tilgang"), HttpStatus.FORBIDDEN)
+                ResponseEntity(OppslagResponseDto(error = "Ingen tilgang", data = null), HttpStatus.FORBIDDEN)
             }
             val aaregRespons = aaregClient.hentArbeidsForhold(dto.ident)
 
             when (aaregRespons.statusCode) {
-                404 -> ResponseEntity(PersonopplysningerResponseDto(error = "Person ikke funnet"), HttpStatus.NOT_FOUND)
-                403 -> ResponseEntity(PersonopplysningerResponseDto(error = "Ingen tilgang"), HttpStatus.FORBIDDEN)
+                404 -> ResponseEntity(OppslagResponseDto(error = "Person ikke funnet", data = null), HttpStatus.NOT_FOUND)
+                403 -> ResponseEntity(OppslagResponseDto(error = "Ingen tilgang", data = null), HttpStatus.FORBIDDEN)
             }
 
             val alleArbeidsforhold = aaregRespons.data
 
             if (alleArbeidsforhold.isEmpty()) {
                 ResponseEntity.ok(
-                    ArbeidsforholdResponseDto(
+                    OppslagResponseDto(
                         data = ArbeidsgiverInformasjon(
                             løpendeArbeidsforhold = emptyList(), historikk = emptyList()
                         )
@@ -59,7 +59,7 @@ class PersonopplysningerController(val aaregClient: AaregClient, val eregClient:
 
 
             ResponseEntity.ok(
-                ArbeidsforholdResponseDto(
+                OppslagResponseDto(
                     data = ArbeidsgiverInformasjon(
                         løpendeArbeidsforhold, historiskeArbeidsforhold
                     )
@@ -69,9 +69,3 @@ class PersonopplysningerController(val aaregClient: AaregClient, val eregClient:
         }
     }
 }
-
-data class ArbeidsforholdRequestDto(val ident: String)
-data class ArbeidsforholdResponseDto(
-    val error: String? = null,
-    val data: ArbeidsgiverInformasjon,
-)

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/InntektController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/InntektController.kt
@@ -34,6 +34,7 @@ class InntektController(
             when (inntektResponse.statusCode) {
                 404 -> ResponseEntity(OppslagResponseDto(error = "Person ikke funnet", data = null), HttpStatus.NOT_FOUND)
                 403 -> ResponseEntity(OppslagResponseDto(error = "Ingen tilgang", data = null), HttpStatus.FORBIDDEN)
+                500 -> ResponseEntity(OppslagResponseDto(error = "Feil i baksystem", data = null), HttpStatus.BAD_GATEWAY)
             }
 
             val lønnsinntekt = inntektResponse.data?.data

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/InntektController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/InntektController.kt
@@ -24,16 +24,16 @@ class InntektController(
 ) {
     @Protected
     @PostMapping("/inntekt")
-    fun hentInntekter(@RequestBody dto: InntektRequestDto): ResponseEntity<InntektResponseDto> {
+    fun hentInntekter(@RequestBody dto: OppslagRequestDto): ResponseEntity<OppslagResponseDto<InntektInformasjon>> {
         return runBlocking {
             if (!brukertilgangService.harBrukerTilgangTilIdent(dto.ident)) {
-                ResponseEntity(InntektResponseDto(error = "Ingen tilgang"), HttpStatus.FORBIDDEN)
+                ResponseEntity(OppslagResponseDto(error = "Ingen tilgang", data = null), HttpStatus.FORBIDDEN)
             }
             val inntektResponse = inntektClient.hentInntekter(dto.ident)
 
             when (inntektResponse.statusCode) {
-                404 -> ResponseEntity(InntektResponseDto(error = "Person ikke funnet"), HttpStatus.NOT_FOUND)
-                403 -> ResponseEntity(InntektResponseDto(error = "Ingen tilgang"), HttpStatus.FORBIDDEN)
+                404 -> ResponseEntity(OppslagResponseDto(error = "Person ikke funnet", data = null), HttpStatus.NOT_FOUND)
+                403 -> ResponseEntity(OppslagResponseDto(error = "Ingen tilgang", data = null), HttpStatus.FORBIDDEN)
             }
 
             val lønnsinntekt = inntektResponse.data?.data
@@ -60,7 +60,7 @@ class InntektController(
                 }
 
             ResponseEntity.ok(
-                InntektResponseDto(
+                OppslagResponseDto(
                     data = InntektInformasjon(lønnsinntekt = lønnsinntekt)
                 )
             )
@@ -68,9 +68,3 @@ class InntektController(
         }
     }
 }
-
-data class InntektRequestDto(val ident: String)
-data class InntektResponseDto(
-    val error: String? = null,
-    val data: InntektInformasjon? = null,
-)

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/InntektController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/InntektController.kt
@@ -1,0 +1,76 @@
+package no.nav.persondataapi.rest.oppslag
+
+import kotlinx.coroutines.runBlocking
+import no.nav.inntekt.generated.model.Loennsinntekt
+import no.nav.persondataapi.ereg.client.EregClient
+import no.nav.persondataapi.inntekt.client.InntektClient
+import no.nav.persondataapi.rest.domain.InntektInformasjon
+import no.nav.persondataapi.rest.domain.Lønnsdetaljer
+import no.nav.persondataapi.service.BrukertilgangService
+import no.nav.persondataapi.service.harHistorikkPåNormallønn
+import no.nav.persondataapi.service.nyeste
+import no.nav.security.token.support.core.api.Protected
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+
+@Controller("/oppslag")
+class InntektController(
+    val inntektClient: InntektClient,
+    val eregClient: EregClient,
+    val brukertilgangService: BrukertilgangService
+) {
+    @Protected
+    @PostMapping("/inntekt")
+    fun hentInntekter(@RequestBody dto: InntektRequestDto): ResponseEntity<InntektResponseDto> {
+        return runBlocking {
+            if (!brukertilgangService.harBrukerTilgangTilIdent(dto.ident)) {
+                ResponseEntity(InntektResponseDto(error = "Ingen tilgang"), HttpStatus.FORBIDDEN)
+            }
+            val inntektResponse = inntektClient.hentInntekter(dto.ident)
+
+            when (inntektResponse.statusCode) {
+                404 -> ResponseEntity(InntektResponseDto(error = "Person ikke funnet"), HttpStatus.NOT_FOUND)
+                403 -> ResponseEntity(InntektResponseDto(error = "Ingen tilgang"), HttpStatus.FORBIDDEN)
+            }
+
+            val lønnsinntekt = inntektResponse.data?.data
+                .orEmpty()
+                .flatMap { historikk ->
+                    val arbeidsgiver = eregClient.hentOrganisasjon(historikk.opplysningspliktig)
+
+                    historikk.versjoner.nyeste()
+                        ?.inntektListe
+                        ?.filterIsInstance<Loennsinntekt>()
+                        ?.map { loenn ->
+                            Lønnsdetaljer(
+                                arbeidsgiver = arbeidsgiver.navn?.sammensattnavn,
+                                periode = historikk.maaned,
+                                arbeidsforhold = "",
+                                stillingsprosent = "",
+                                lønnstype = loenn.beskrivelse,
+                                antall = loenn.antall,
+                                beløp = loenn.beloep,
+                                harFlereVersjoner = historikk.harHistorikkPåNormallønn()
+                            )
+                        }
+                        .orEmpty()
+                }
+
+            ResponseEntity.ok(
+                InntektResponseDto(
+                    data = InntektInformasjon(lønnsinntekt = lønnsinntekt)
+                )
+            )
+
+        }
+    }
+}
+
+data class InntektRequestDto(val ident: String)
+data class InntektResponseDto(
+    val error: String? = null,
+    val data: InntektInformasjon? = null,
+)

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/InntektController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/InntektController.kt
@@ -26,7 +26,7 @@ class InntektController(
     @PostMapping("/inntekt")
     fun hentInntekter(@RequestBody dto: OppslagRequestDto): ResponseEntity<OppslagResponseDto<InntektInformasjon>> {
         return runBlocking {
-            if (!brukertilgangService.harBrukerTilgangTilIdent(dto.ident)) {
+            if (!brukertilgangService.harSaksbehandlerTilgangTilPersonIdent(dto.ident)) {
                 ResponseEntity(OppslagResponseDto(error = "Ingen tilgang", data = null), HttpStatus.FORBIDDEN)
             }
             val inntektResponse = inntektClient.hentInntekter(dto.ident)

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/OppslagRequestDto.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/OppslagRequestDto.kt
@@ -1,0 +1,5 @@
+package no.nav.persondataapi.rest.oppslag
+
+data class OppslagRequestDto(
+    val ident: String
+)

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/OppslagResponseDto.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/OppslagResponseDto.kt
@@ -1,0 +1,6 @@
+package no.nav.persondataapi.rest.oppslag
+
+data class OppslagResponseDto<T>(
+    val error: String? = null,
+    val data: T? = null,
+)

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerController.kt
@@ -40,7 +40,7 @@ class PersonopplysningerController(val pdlClient: PdlClient, val brukertilgangSe
                ResponseEntity(PersonopplysningerResponseDto(error = "Ingen tilgang"),HttpStatus.FORBIDDEN)
             }
 
-            val pdlResultat  = resultat.data as Person
+            val pdlResultat  = resultat.data!!
             val foreldreOgBarn = pdlResultat.forelderBarnRelasjon.associate { Pair(it.relatertPersonsIdent!!, it.relatertPersonsRolle.name) }
             val statsborgerskap = pdlResultat.statsborgerskap.map { it.land }
             val ektefelle = pdlResultat.sivilstand.filter { it.relatertVedSivilstand!=null }.associate { Pair(it.relatertVedSivilstand!!,it.type.name)}

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerController.kt
@@ -25,16 +25,16 @@ import java.time.Period
 class PersonopplysningerController(val pdlClient: PdlClient, val brukertilgangService: BrukertilgangService) {
     @Protected
     @PostMapping("/personopplysninger")
-    fun hentPersonopplysninger(@RequestBody dto: PersonopplysningerRequestDto): ResponseEntity<PersonopplysningerResponseDto> {
+    fun hentPersonopplysninger(@RequestBody dto: OppslagRequestDto): ResponseEntity<OppslagResponseDto<PersonInformasjon>> {
         return runBlocking {
             if (!brukertilgangService.harBrukerTilgangTilIdent(dto.ident)) {
-                ResponseEntity(PersonopplysningerResponseDto(error = "Ingen tilgang"),HttpStatus.FORBIDDEN)
+                ResponseEntity(OppslagResponseDto(error = "Ingen tilgang", data = null),HttpStatus.FORBIDDEN)
             }
             val resultat = pdlClient.hentPersonv2(dto.ident)
 
             when (resultat.statusCode) {
-                404 -> ResponseEntity(PersonopplysningerResponseDto(error = "Person ikke funnet"),HttpStatus.NOT_FOUND)
-                403 -> ResponseEntity(PersonopplysningerResponseDto(error = "Ingen tilgang"),HttpStatus.FORBIDDEN)
+                404 -> ResponseEntity(OppslagResponseDto(error = "Person ikke funnet", data = null),HttpStatus.NOT_FOUND)
+                403 -> ResponseEntity(OppslagResponseDto(error = "Ingen tilgang", data = null),HttpStatus.FORBIDDEN)
             }
 
             val pdlResultat  = resultat.data!!
@@ -57,13 +57,7 @@ class PersonopplysningerController(val pdlClient: PdlClient, val brukertilgangSe
                 alder = pdlResultat.foedselsdato.first().foedselsdato?.let { Period.between(LocalDate.parse(it), LocalDate.now()).years } ?: -1,
             )
 
-            ResponseEntity(PersonopplysningerResponseDto(data = personopplysninger), HttpStatus.OK)
+            ResponseEntity(OppslagResponseDto(data = personopplysninger), HttpStatus.OK)
         }
     }
 }
-
-data class PersonopplysningerRequestDto(val ident: String)
-data class PersonopplysningerResponseDto(
-    val error: String? = null,
-    val data: PersonInformasjon? = null
-)

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerController.kt
@@ -32,12 +32,9 @@ class PersonopplysningerController(val pdlClient: PdlClient, val brukertilgangSe
             }
             val resultat = pdlClient.hentPersonv2(dto.ident)
 
-            if (resultat.statusCode == 404 || resultat.data == null) {
-               ResponseEntity(PersonopplysningerResponseDto(error = "Person ikke funnet"),HttpStatus.NOT_FOUND)
-            }
-
-            if (resultat.statusCode == 403) {
-               ResponseEntity(PersonopplysningerResponseDto(error = "Ingen tilgang"),HttpStatus.FORBIDDEN)
+            when (resultat.statusCode) {
+                404 -> ResponseEntity(PersonopplysningerResponseDto(error = "Person ikke funnet"),HttpStatus.NOT_FOUND)
+                403 -> ResponseEntity(PersonopplysningerResponseDto(error = "Ingen tilgang"),HttpStatus.FORBIDDEN)
             }
 
             val pdlResultat  = resultat.data!!

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerController.kt
@@ -35,6 +35,7 @@ class PersonopplysningerController(val pdlClient: PdlClient, val brukertilgangSe
             when (resultat.statusCode) {
                 404 -> ResponseEntity(OppslagResponseDto(error = "Person ikke funnet", data = null),HttpStatus.NOT_FOUND)
                 403 -> ResponseEntity(OppslagResponseDto(error = "Ingen tilgang", data = null),HttpStatus.FORBIDDEN)
+                500 -> ResponseEntity(OppslagResponseDto(error = "Feil i baksystem", data = null), HttpStatus.BAD_GATEWAY)
             }
 
             val pdlResultat  = resultat.data!!

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerController.kt
@@ -1,0 +1,68 @@
+package no.nav.persondataapi.rest.oppslag
+
+import kotlinx.coroutines.runBlocking
+import no.nav.persondataapi.generated.hentperson.Person
+import no.nav.persondataapi.pdl.client.PdlClient
+import no.nav.persondataapi.rest.domain.Navn
+import no.nav.persondataapi.rest.domain.PersonInformasjon
+import no.nav.persondataapi.service.gjeldendeEtternavn
+import no.nav.persondataapi.service.gjeldendeFornavn
+import no.nav.persondataapi.service.gjeldendeMellomnavn
+import no.nav.persondataapi.service.gjeldendeSivilStand
+import no.nav.persondataapi.service.nåværendeBostedsadresse
+import no.nav.security.token.support.core.api.Protected
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import java.time.LocalDate
+import java.time.Period
+
+
+@Controller("/oppslag")
+class PersonopplysningerController(val pdlClient: PdlClient) {
+    @Protected
+    @PostMapping("/personopplysninger")
+    fun hentPersonopplysninger(@RequestBody dto: PersonopplysningerRequestDto): ResponseEntity<PersonopplysningerResponseDto> {
+        return runBlocking {
+            val resultat = pdlClient.hentPersonv2(dto.ident)
+
+            if (resultat.statusCode == 404 || resultat.data == null) {
+               ResponseEntity(PersonopplysningerResponseDto(error = "Person ikke funnet"),HttpStatus.NOT_FOUND)
+            }
+
+            if (resultat.statusCode == 403) {
+               ResponseEntity(PersonopplysningerResponseDto(error = "Ingen tilgang"),HttpStatus.FORBIDDEN)
+            }
+
+            val pdlResultat  = resultat.data as Person
+            val foreldreOgBarn = pdlResultat.forelderBarnRelasjon.associate { Pair(it.relatertPersonsIdent!!, it.relatertPersonsRolle.name) }
+            val statsborgerskap = pdlResultat.statsborgerskap.map { it.land }
+            val ektefelle = pdlResultat.sivilstand.filter { it.relatertVedSivilstand!=null }.associate { Pair(it.relatertVedSivilstand!!,it.type.name)}
+            val familiemedlemmer = foreldreOgBarn + ektefelle
+
+            val personopplysninger = PersonInformasjon(
+                navn = Navn(
+                    pdlResultat.gjeldendeFornavn(),
+                    mellomnavn = pdlResultat.gjeldendeMellomnavn(),
+                    etternavn = pdlResultat.gjeldendeEtternavn(),
+                ),
+                aktørId = dto.ident,
+                adresse = pdlResultat.nåværendeBostedsadresse(),
+                familemedlemmer = familiemedlemmer,
+                statsborgerskap = statsborgerskap,
+                sivilstand = pdlResultat.gjeldendeSivilStand(),
+                alder = pdlResultat.foedselsdato.first().foedselsdato?.let { Period.between(LocalDate.parse(it), LocalDate.now()).years } ?: -1,
+            )
+
+            ResponseEntity(PersonopplysningerResponseDto(data = personopplysninger), HttpStatus.OK)
+        }
+    }
+}
+
+data class PersonopplysningerRequestDto(val ident: String)
+data class PersonopplysningerResponseDto(
+    val error: String? = null,
+    val data: PersonInformasjon? = null
+)

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerController.kt
@@ -58,7 +58,7 @@ class PersonopplysningerController(val pdlClient: PdlClient, val brukertilgangSe
                 alder = pdlResultat.foedselsdato.first().foedselsdato?.let { Period.between(LocalDate.parse(it), LocalDate.now()).years } ?: -1,
             )
 
-            ResponseEntity(OppslagResponseDto(data = personopplysninger), HttpStatus.OK)
+            ResponseEntity.ok(OppslagResponseDto(data = personopplysninger))
         }
     }
 }

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerController.kt
@@ -5,6 +5,7 @@ import no.nav.persondataapi.generated.hentperson.Person
 import no.nav.persondataapi.pdl.client.PdlClient
 import no.nav.persondataapi.rest.domain.Navn
 import no.nav.persondataapi.rest.domain.PersonInformasjon
+import no.nav.persondataapi.service.BrukertilgangService
 import no.nav.persondataapi.service.gjeldendeEtternavn
 import no.nav.persondataapi.service.gjeldendeFornavn
 import no.nav.persondataapi.service.gjeldendeMellomnavn
@@ -21,11 +22,14 @@ import java.time.Period
 
 
 @Controller("/oppslag")
-class PersonopplysningerController(val pdlClient: PdlClient) {
+class PersonopplysningerController(val pdlClient: PdlClient, val brukertilgangService: BrukertilgangService) {
     @Protected
     @PostMapping("/personopplysninger")
     fun hentPersonopplysninger(@RequestBody dto: PersonopplysningerRequestDto): ResponseEntity<PersonopplysningerResponseDto> {
         return runBlocking {
+            if (!brukertilgangService.harBrukerTilgangTilIdent(dto.ident)) {
+                ResponseEntity(PersonopplysningerResponseDto(error = "Ingen tilgang"),HttpStatus.FORBIDDEN)
+            }
             val resultat = pdlClient.hentPersonv2(dto.ident)
 
             if (resultat.statusCode == 404 || resultat.data == null) {

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerController.kt
@@ -27,7 +27,7 @@ class PersonopplysningerController(val pdlClient: PdlClient, val brukertilgangSe
     @PostMapping("/personopplysninger")
     fun hentPersonopplysninger(@RequestBody dto: OppslagRequestDto): ResponseEntity<OppslagResponseDto<PersonInformasjon>> {
         return runBlocking {
-            if (!brukertilgangService.harBrukerTilgangTilIdent(dto.ident)) {
+            if (!brukertilgangService.harSaksbehandlerTilgangTilPersonIdent(dto.ident)) {
                 ResponseEntity(OppslagResponseDto(error = "Ingen tilgang", data = null),HttpStatus.FORBIDDEN)
             }
             val resultat = pdlClient.hentPersonv2(dto.ident)

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/StønadController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/StønadController.kt
@@ -23,7 +23,7 @@ class StønadController(
     @PostMapping("/stønad")
     fun hentStønader(@RequestBody dto: OppslagRequestDto): ResponseEntity<OppslagResponseDto<List<Stonad>>> {
         return runBlocking {
-            if (!brukertilgangService.harBrukerTilgangTilIdent(dto.ident)) {
+            if (!brukertilgangService.harSaksbehandlerTilgangTilPersonIdent(dto.ident)) {
                 ResponseEntity(OppslagResponseDto(error = "Ingen tilgang", data = null), HttpStatus.FORBIDDEN)
             }
             val utbetalingResponse = utbetalingClient.hentUtbetalingerForBruker(dto.ident)

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/StønadController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/StønadController.kt
@@ -31,6 +31,7 @@ class StønadController(
             when (utbetalingResponse.statusCode) {
                 404 -> ResponseEntity(OppslagResponseDto(error = "Person ikke funnet", data = null), HttpStatus.NOT_FOUND)
                 403 -> ResponseEntity(OppslagResponseDto(error = "Ingen tilgang", data = null), HttpStatus.FORBIDDEN)
+                500 -> ResponseEntity(OppslagResponseDto(error = "Feil i baksystem", data = null), HttpStatus.BAD_GATEWAY)
             }
 
             if (utbetalingResponse.data?.utbetalinger.isNullOrEmpty()) {

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/StønadController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/StønadController.kt
@@ -1,0 +1,66 @@
+package no.nav.persondataapi.rest.oppslag
+
+import kotlinx.coroutines.runBlocking
+import no.nav.persondataapi.rest.domain.Periode
+import no.nav.persondataapi.rest.domain.PeriodeInformasjon
+import no.nav.persondataapi.rest.domain.Stonad
+import no.nav.persondataapi.service.BrukertilgangService
+import no.nav.persondataapi.utbetaling.client.UtbetalingClient
+import no.nav.security.token.support.core.api.Protected
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import kotlin.collections.emptyList
+
+@Controller("/oppslag")
+class StønadController(
+    val utbetalingClient: UtbetalingClient,
+    val brukertilgangService: BrukertilgangService
+) {
+    @Protected
+    @PostMapping("/stønad")
+    fun hentStønader(@RequestBody dto: OppslagRequestDto): ResponseEntity<OppslagResponseDto<List<Stonad>>> {
+        return runBlocking {
+            if (!brukertilgangService.harBrukerTilgangTilIdent(dto.ident)) {
+                ResponseEntity(OppslagResponseDto(error = "Ingen tilgang", data = null), HttpStatus.FORBIDDEN)
+            }
+            val utbetalingResponse = utbetalingClient.hentUtbetalingerForAktor(dto.ident)
+
+            when (utbetalingResponse.statusCode) {
+                404 -> ResponseEntity(OppslagResponseDto(error = "Person ikke funnet", data = null), HttpStatus.NOT_FOUND)
+                403 -> ResponseEntity(OppslagResponseDto(error = "Ingen tilgang", data = null), HttpStatus.FORBIDDEN)
+            }
+
+            if (utbetalingResponse.data?.utbetalinger.isNullOrEmpty()) {
+                ResponseEntity.ok(OppslagResponseDto(data = emptyList<Stonad>()))
+            }
+
+            val utbetalinger = utbetalingResponse.data?.utbetalinger.orEmpty()
+            val stønader: List<Stonad> =
+                utbetalinger
+                    .asSequence()
+                    .flatMap { it.ytelseListe.asSequence() }
+                    .filter { it.ytelsestype != null }
+                    .groupBy { it.ytelsestype }
+                    .map { (type, liste) ->
+                        val perioder = liste.map { y ->
+                            PeriodeInformasjon(
+                                periode = Periode(fom = y.ytelsesperiode.fom, tom = y.ytelsesperiode.tom),
+                                beløp = y.ytelseNettobeloep,
+                                kilde = "SOKOS",
+                                info = y.bilagsnummer
+                            )
+                        }
+                        Stonad(stonadType = type!!, perioder)
+                    }
+                    .toList()
+            ResponseEntity.ok(
+                OppslagResponseDto(
+                    data = stønader
+                )
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/StønadController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/StønadController.kt
@@ -26,7 +26,7 @@ class StønadController(
             if (!brukertilgangService.harBrukerTilgangTilIdent(dto.ident)) {
                 ResponseEntity(OppslagResponseDto(error = "Ingen tilgang", data = null), HttpStatus.FORBIDDEN)
             }
-            val utbetalingResponse = utbetalingClient.hentUtbetalingerForAktor(dto.ident)
+            val utbetalingResponse = utbetalingClient.hentUtbetalingerForBruker(dto.ident)
 
             when (utbetalingResponse.statusCode) {
                 404 -> ResponseEntity(OppslagResponseDto(error = "Person ikke funnet", data = null), HttpStatus.NOT_FOUND)

--- a/src/main/kotlin/no/nav/persondataapi/service/BrukertilgangService.kt
+++ b/src/main/kotlin/no/nav/persondataapi/service/BrukertilgangService.kt
@@ -16,11 +16,10 @@ class BrukertilgangService(
 
         val groups = token.jwtTokenClaims.get("groups") as? List<String> ?: emptyList()
 
-        return if (tilgangService.harUtvidetTilgang(groups)) {
-            true
-        } else {
-            val status = tilgangService.sjekkTilgang(ident, token.encodedToken)
-            return status == 200
+        if (tilgangService.harUtvidetTilgang(groups)) {
+            return true
         }
+        val status = tilgangService.sjekkTilgang(ident, token.encodedToken)
+        return status == 200
     }
 }

--- a/src/main/kotlin/no/nav/persondataapi/service/BrukertilgangService.kt
+++ b/src/main/kotlin/no/nav/persondataapi/service/BrukertilgangService.kt
@@ -8,7 +8,7 @@ class BrukertilgangService(
     val tokenValidationContextHolder: TokenValidationContextHolder,
     val tilgangService: TilgangService,
 ) {
-    fun harBrukerTilgangTilIdent(ident: String): Boolean {
+    fun harSaksbehandlerTilgangTilPersonIdent(ident: String): Boolean {
         val context = tokenValidationContextHolder.getTokenValidationContext()
         val token = context.firstValidToken ?: throw IllegalStateException("Fant ikke gyldig token")
 

--- a/src/main/kotlin/no/nav/persondataapi/service/BrukertilgangService.kt
+++ b/src/main/kotlin/no/nav/persondataapi/service/BrukertilgangService.kt
@@ -1,8 +1,6 @@
 package no.nav.persondataapi.service
 
-import no.nav.security.token.support.core.context.TokenValidationContext
 import no.nav.security.token.support.core.context.TokenValidationContextHolder
-import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 
 @Service

--- a/src/main/kotlin/no/nav/persondataapi/service/BrukertilgangService.kt
+++ b/src/main/kotlin/no/nav/persondataapi/service/BrukertilgangService.kt
@@ -1,0 +1,26 @@
+package no.nav.persondataapi.service
+
+import no.nav.security.token.support.core.context.TokenValidationContext
+import no.nav.security.token.support.core.context.TokenValidationContextHolder
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+
+@Service
+class BrukertilgangService(
+    val tokenValidationContextHolder: TokenValidationContextHolder,
+    val tilgangService: TilgangService,
+) {
+    fun harBrukerTilgangTilIdent(ident: String): Boolean {
+        val context = tokenValidationContextHolder.getTokenValidationContext()
+        val token = context.firstValidToken ?: throw IllegalStateException("Fant ikke gyldig token")
+
+        val groups = token.jwtTokenClaims.get("groups") as? List<String> ?: emptyList()
+
+        return if (tilgangService.harUtvidetTilgang(groups)) {
+            true
+        } else {
+            val status = tilgangService.sjekkTilgang(ident, token.encodedToken)
+            return status == 200
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/persondataapi/service/ExtentionFunctions.kt
+++ b/src/main/kotlin/no/nav/persondataapi/service/ExtentionFunctions.kt
@@ -21,7 +21,7 @@ import no.nav.persondataapi.rest.domain.Stonad
 import java.time.LocalDate
 import java.time.Period
 
-fun Arbeidsforhold.hentOrgNummerTilArbeidsSted(): String {
+fun Arbeidsforhold.hentOrgNummerTilArbeidssted(): String {
     val identOrgNummer  = this.arbeidssted.identer.firstOrNull() { it.type == Identtype.ORGANISASJONSNUMMER }
     if (identOrgNummer == null){
         return "Ingen OrgNummer"
@@ -215,10 +215,10 @@ fun GrunnlagsData.getArbeidsgiverInformasjon(): ArbeidsgiverInformasjon{
         * map løpende arbeidsforhold
         * */
         val lopende = lopendeArbeidsforhold.map { arbeidsforhold ->
-            mapArbeidsforholdTilArbeidsGiverData(arbeidsforhold,this.eregDataRespons)
+            mapArbeidsforholdTilArbeidsgiverData(arbeidsforhold,this.eregDataRespons)
         }
         val historisk = historiskeArbeidsforhold.map { arbeidsforhold ->
-            mapArbeidsforholdTilArbeidsGiverData(arbeidsforhold,this.eregDataRespons)
+            mapArbeidsforholdTilArbeidsgiverData(arbeidsforhold,this.eregDataRespons)
         }
         return ArbeidsgiverInformasjon(
             lopende,historisk

--- a/src/main/kotlin/no/nav/persondataapi/service/ExtentionFunctions.kt
+++ b/src/main/kotlin/no/nav/persondataapi/service/ExtentionFunctions.kt
@@ -12,7 +12,7 @@ import no.nav.persondataapi.generated.hentperson.Person
 import no.nav.persondataapi.rest.domain.NorskAdresse
 import no.nav.persondataapi.rest.domain.ArbeidsgiverInformasjon
 import no.nav.persondataapi.rest.domain.Bostedsadresse
-import no.nav.persondataapi.rest.domain.LoensDetaljer
+import no.nav.persondataapi.rest.domain.Lønnsdetaljer
 import no.nav.persondataapi.rest.domain.Navn
 import no.nav.persondataapi.rest.domain.Periode
 import no.nav.persondataapi.rest.domain.PeriodeInformasjon
@@ -40,22 +40,20 @@ fun Map<String, EregRespons>.orgNummerTilOrgNavn(orgnummer:String): String {
 
 }
 
-fun GrunnlagsData.getLønnsinntektOversikt(): List<LoensDetaljer> {
+fun GrunnlagsData.getLønnsinntektOversikt(): List<Lønnsdetaljer> {
     if (this.inntektDataRespons==null || this.inntektDataRespons.data==null){
         return emptyList()
     }
     else {
         val listeAvInntektHistorikk = inntektDataRespons.data.data?: emptyList()
 
-        val  ret: MutableList<LoensDetaljer> = mutableListOf()
+        val  ret: MutableList<Lønnsdetaljer> = mutableListOf()
         listeAvInntektHistorikk.forEach { historikk ->
-            val harHistorikkPaaLoennsinntekt = historikk.historikkPaaNormalLoenn()
-            println(harHistorikkPaaLoennsinntekt)
+            val harHistorikkPaaLoennsinntekt = historikk.harHistorikkPåNormallønn()
             val nyeste = historikk.versjoner.nyeste()
-            if (nyeste !=null && nyeste.inntektListe!=null){
-                val liste = nyeste.inntektListe ?: emptyList()
-                liste.filter { it is Loennsinntekt }.map { it as Loennsinntekt }.forEach { loenn ->
-                    ret.add(LoensDetaljer(
+            if (nyeste?.inntektListe != null) {
+                nyeste.inntektListe.filter { it is Loennsinntekt }.map { it as Loennsinntekt }.forEach { loenn ->
+                    ret.add(Lønnsdetaljer(
                         arbeidsgiver = this.eregDataRespons.orgNummerTilOrgNavn(historikk.opplysningspliktig),
                         periode = historikk.maaned,
                         arbeidsforhold = "",
@@ -155,16 +153,17 @@ fun List<Inntektsinformasjon>?.nyeste(): Inntektsinformasjon? {
 
 
 
-fun HistorikkData.historikkPaaNormalLoenn():Boolean{
+fun HistorikkData.harHistorikkPåNormallønn() : Boolean {
     val versjoner = this.versjoner?:emptyList()
     var count = 0
+
     versjoner.forEach {
-            intektInformasjon ->
-        val inntektListe = intektInformasjon.inntektListe?:emptyList()
+            inntektInformasjon ->
+        val inntektListe = inntektInformasjon.inntektListe ?: emptyList()
         val antall = inntektListe.filterNot { inntekt -> inntekt is YtelseFraOffentlige }.size
-        if (antall>0) count++
+        if (antall > 0) count++
     }
-    return count>1
+    return count > 1
 }
 
 

--- a/src/main/kotlin/no/nav/persondataapi/service/ResponsMappingService.kt
+++ b/src/main/kotlin/no/nav/persondataapi/service/ResponsMappingService.kt
@@ -47,8 +47,8 @@ class ResponsMappingService(
 
 
 
-fun mapArbeidsforholdTilArbeidsGiverData(arbeidsforhold: Arbeidsforhold,eregDataRespons: Map<String,EregRespons>): ArbeidsgiverData {
-    val orgnummer = arbeidsforhold.hentOrgNummerTilArbeidsSted()
+fun mapArbeidsforholdTilArbeidsgiverData(arbeidsforhold: Arbeidsforhold, eregDataRespons: Map<String,EregRespons>): ArbeidsgiverData {
+    val orgnummer = arbeidsforhold.hentOrgNummerTilArbeidssted()
     return ArbeidsgiverData(eregDataRespons.orgNummerTilOrgNavn(orgnummer),
         orgnummer,
         eregDataRespons.orgnummerTilAdresse(orgnummer),

--- a/src/main/kotlin/no/nav/persondataapi/service/dataproviders/AAregGrunnlagsProvider.kt
+++ b/src/main/kotlin/no/nav/persondataapi/service/dataproviders/AAregGrunnlagsProvider.kt
@@ -2,10 +2,6 @@ package no.nav.persondataapi.service.dataproviders
 
 
 import no.nav.persondataapi.aareg.client.AaregClient
-import no.nav.persondataapi.service.dataproviders.GrunnlagsProvider
-import no.nav.persondataapi.service.dataproviders.GrunnlagsType
-import no.nav.persondataapi.service.dataproviders.GrunnlagsdelResultat
-import no.nav.persondataapi.utbetaling.client.UtbetalingClient
 
 import org.springframework.stereotype.Component
 
@@ -14,7 +10,7 @@ class AAregGrunnlagsProvider(val aaregClient: AaregClient) : GrunnlagsProvider {
     override val type = GrunnlagsType.ARBEIDSFORHOLD
 
     override suspend fun hent(kontekst: GrunnlagsKontekst): GrunnlagsdelResultat {
-        val resultat = aaregClient.hentArbeidsForhold(kontekst.fnr)
+        val resultat = aaregClient.hentArbeidsforhold(kontekst.fnr)
         return GrunnlagsdelResultat(
             type = type,
             data = resultat.data,

--- a/src/main/kotlin/no/nav/persondataapi/service/dataproviders/AAregGrunnlagsProvider.kt
+++ b/src/main/kotlin/no/nav/persondataapi/service/dataproviders/AAregGrunnlagsProvider.kt
@@ -14,7 +14,7 @@ class AAregGrunnlagsProvider(val aaregClient: AaregClient) : GrunnlagsProvider {
     override val type = GrunnlagsType.ARBEIDSFORHOLD
 
     override suspend fun hent(kontekst: GrunnlagsKontekst): GrunnlagsdelResultat {
-        val resultat = aaregClient.hentArbeidsForhold(kontekst.fnr,kontekst.token)
+        val resultat = aaregClient.hentArbeidsForhold(kontekst.fnr)
         return GrunnlagsdelResultat(
             type = type,
             data = resultat.data,

--- a/src/main/kotlin/no/nav/persondataapi/service/dataproviders/InntektGrunnlagProvider.kt
+++ b/src/main/kotlin/no/nav/persondataapi/service/dataproviders/InntektGrunnlagProvider.kt
@@ -8,7 +8,7 @@ class InntektGrunnlagProvider(val inntektClient: InntektClient) : GrunnlagsProvi
     override val type = GrunnlagsType.INNTEKT
     override suspend fun hent(kontekst: GrunnlagsKontekst): GrunnlagsdelResultat
     {
-        val resultat = inntektClient.hentInntekter(kontekst.fnr,kontekst.token)
+        val resultat = inntektClient.hentInntekter(kontekst.fnr)
         return GrunnlagsdelResultat(
             type = type,
             data = resultat.data,

--- a/src/main/kotlin/no/nav/persondataapi/service/dataproviders/UtbetalingGrunnlagsProvider.kt
+++ b/src/main/kotlin/no/nav/persondataapi/service/dataproviders/UtbetalingGrunnlagsProvider.kt
@@ -13,7 +13,7 @@ class UtbetalingGrunnlagsProvider(val utbetalingClient: UtbetalingClient) : Grun
     override val type = GrunnlagsType.UTBETALINGER
 
     override suspend fun hent(kontekst: GrunnlagsKontekst): GrunnlagsdelResultat {
-        val resultat = utbetalingClient.hentUtbetalingerForAktor(kontekst.fnr,kontekst.token)
+        val resultat = utbetalingClient.hentUtbetalingerForAktor(kontekst.fnr)
         return GrunnlagsdelResultat(
             type = type,
             data = resultat.data,

--- a/src/main/kotlin/no/nav/persondataapi/service/dataproviders/UtbetalingGrunnlagsProvider.kt
+++ b/src/main/kotlin/no/nav/persondataapi/service/dataproviders/UtbetalingGrunnlagsProvider.kt
@@ -1,9 +1,6 @@
 package no.nav.persondataapi.service.dataproviders
 
 
-import no.nav.persondataapi.service.dataproviders.GrunnlagsProvider
-import no.nav.persondataapi.service.dataproviders.GrunnlagsType
-import no.nav.persondataapi.service.dataproviders.GrunnlagsdelResultat
 import no.nav.persondataapi.utbetaling.client.UtbetalingClient
 
 import org.springframework.stereotype.Component
@@ -13,7 +10,7 @@ class UtbetalingGrunnlagsProvider(val utbetalingClient: UtbetalingClient) : Grun
     override val type = GrunnlagsType.UTBETALINGER
 
     override suspend fun hent(kontekst: GrunnlagsKontekst): GrunnlagsdelResultat {
-        val resultat = utbetalingClient.hentUtbetalingerForAktor(kontekst.fnr)
+        val resultat = utbetalingClient.hentUtbetalingerForBruker(kontekst.fnr)
         return GrunnlagsdelResultat(
             type = type,
             data = resultat.data,

--- a/src/main/kotlin/no/nav/persondataapi/utbetaling/client/UtbetalingClient.kt
+++ b/src/main/kotlin/no/nav/persondataapi/utbetaling/client/UtbetalingClient.kt
@@ -1,6 +1,4 @@
 package    no.nav.persondataapi.utbetaling.client
-import com.fasterxml.jackson.databind.JsonNode
-import no.nav.persondataapi.configuration.JsonUtils
 import no.nav.persondataapi.domain.UtbetalingRespons
 import no.nav.persondataapi.domain.UtbetalingResultat
 import no.nav.persondataapi.service.SCOPE
@@ -22,7 +20,7 @@ class UtbetalingClient(
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    fun hentUtbetalingerForAktor(fnr: String): UtbetalingResultat {
+    fun hentUtbetalingerForBruker(fnr: String): UtbetalingResultat {
         return runCatching {
 
             val requestBody = RequestBody(

--- a/src/main/kotlin/no/nav/persondataapi/utbetaling/client/UtbetalingClient.kt
+++ b/src/main/kotlin/no/nav/persondataapi/utbetaling/client/UtbetalingClient.kt
@@ -22,7 +22,7 @@ class UtbetalingClient(
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    fun hentUtbetalingerForAktor(fnr: String,token:String): UtbetalingResultat {
+    fun hentUtbetalingerForAktor(fnr: String): UtbetalingResultat {
         return runCatching {
 
             val requestBody = RequestBody(
@@ -68,14 +68,6 @@ class UtbetalingClient(
                 }
             }
         )
-    }
-
-    private inline fun <reified T> readJsonFileToDto(filename: String): T {
-        val json = object {}.javaClass.classLoader.getResource(filename)
-            ?.readText(Charsets.UTF_8)
-            ?: throw IllegalArgumentException("Finner ikke fil: $filename")
-
-        return JsonUtils.fromJson(json)
     }
 }
 data class RequestBody(

--- a/src/test/kotlin/no/nav/persondataapi/service/ExtentionFunctionTests.kt
+++ b/src/test/kotlin/no/nav/persondataapi/service/ExtentionFunctionTests.kt
@@ -1,7 +1,6 @@
 package no.nav.persondataapi.service
 
 import no.nav.inntekt.generated.model.HistorikkData
-import no.nav.inntekt.generated.model.Inntekt
 import no.nav.inntekt.generated.model.Inntektsinformasjon
 import no.nav.inntekt.generated.model.Loennsinntekt
 import no.nav.inntekt.generated.model.YtelseFraOffentlige
@@ -22,7 +21,7 @@ class ExtentionFunctionTests {
             norskident = "12345678901",
             versjoner = emptyList(),
         )
-        Assertions.assertFalse(historikkData.historikkPaaNormalLoenn())
+        Assertions.assertFalse(historikkData.harHistorikkPåNormallønn())
     }
     @Test
     fun kunYtelseFraOffentligeSkalIkkeTelleIHistorikken() {
@@ -72,7 +71,7 @@ class ExtentionFunctionTests {
 
             ),
         )
-        Assertions.assertFalse(historikkData.historikkPaaNormalLoenn())
+        Assertions.assertFalse(historikkData.harHistorikkPåNormallønn())
     }
 
     @Test
@@ -123,7 +122,7 @@ class ExtentionFunctionTests {
 
             ),
         )
-        Assertions.assertFalse(historikkData.historikkPaaNormalLoenn())
+        Assertions.assertFalse(historikkData.harHistorikkPåNormallønn())
     }
 
     @Test
@@ -174,7 +173,7 @@ class ExtentionFunctionTests {
 
             ),
         )
-        Assertions.assertTrue(historikkData.historikkPaaNormalLoenn())
+        Assertions.assertTrue(historikkData.harHistorikkPåNormallønn())
     }
 
 }


### PR DESCRIPTION
Denne PRen (stor, I know) legger til egne endepunkter for de forskjellige bolkene på oppslag bruker. Det gjør at vi kan vise data etterhvert som de dukker opp, istedenfor å vente til siste rest.

Når vi har migrert over frontenden vår til å bruke disse, kan vi slette haugevis av kode – men enn så lenge må det ligge der.

Tar gjerne tilbakemeldinger på hvordan jeg har løst ting – jeg er ingen ekspert på Kotlin akkurat.