### PR TITLE
Legg til endepunkt for å slå opp en personbrukers eksistens og tilgang

### DIFF
--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonbrukerController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonbrukerController.kt
@@ -15,9 +15,7 @@ class PersonbrukerController(
 ) {
     @PostMapping
     fun hentStatusPåBrukeroppslag(@RequestBody dto: OppslagRequestDto): ResponseEntity<Void> {
-        return runBlocking {
-            val status  = brukertilgangService.hentStatusPåBruker(dto.ident)
-            ResponseEntity.status(status).build();
-        }
+        val status = brukertilgangService.hentStatusPåBruker(dto.ident)
+        return ResponseEntity.status(status).build()
     }
 }

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonbrukerController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonbrukerController.kt
@@ -1,0 +1,23 @@
+package no.nav.persondataapi.rest.oppslag
+
+import kotlinx.coroutines.runBlocking
+import no.nav.persondataapi.service.BrukertilgangService
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Controller
+@RequestMapping("/oppslag/personbruker")
+class PersonbrukerController(
+    val brukertilgangService: BrukertilgangService,
+) {
+    @PostMapping
+    fun hentStatusPåBrukeroppslag(@RequestBody dto: OppslagRequestDto): ResponseEntity<Void> {
+        return runBlocking {
+            val status  = brukertilgangService.hentStatusPåBruker(dto.ident)
+            ResponseEntity.status(status).build();
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/persondataapi/service/BrukertilgangService.kt
+++ b/src/main/kotlin/no/nav/persondataapi/service/BrukertilgangService.kt
@@ -9,15 +9,19 @@ class BrukertilgangService(
     val tilgangService: TilgangService,
 ) {
     fun harSaksbehandlerTilgangTilPersonIdent(ident: String): Boolean {
+        val status = hentStatusPåBruker(ident)
+        return status == 200
+    }
+
+    fun hentStatusPåBruker(ident: String): Int {
         val context = tokenValidationContextHolder.getTokenValidationContext()
         val token = context.firstValidToken ?: throw IllegalStateException("Fant ikke gyldig token")
 
         val groups = token.jwtTokenClaims.get("groups") as? List<String> ?: emptyList()
 
-        if (tilgangService.harUtvidetTilgang(groups)) {
-            return true
+        return when (val status = tilgangService.sjekkTilgang(ident, token.encodedToken)) {
+            403 -> if (tilgangService.harUtvidetTilgang(groups)) 200 else status
+            else -> status
         }
-        val status = tilgangService.sjekkTilgang(ident, token.encodedToken)
-        return status == 200
     }
 }


### PR DESCRIPTION
Denne PRen legger til et endepunkt vi kan kalle før vi kaller andre APIer:

- Hvis brukeren ikke finnes, returner 404
- Hvis brukeren finnes, men du ikke har tilgang, returner 403
- Hvis brukeren finnes, man ikke har tilgang per se, men man tilhører en utvidet gruppe, returner 200
- Hvis brukeren finnes og man har tilgang (de fleste tilfeller) returner 200
- Hvis tilgangsmaskinen returnerer noe annet, returner den statuskoden

Ulempen her er at vi må sjekke tilgangsmaskinen uansett om man tilhører en utvidet gruppe eller ikke. Det er såpass få som kommer til å bli behandlet den løypen, at vi kan ta oss tid til å optimalisere for det generelle valget (uansett greit å ikke fortsette kallene dersom brukeren ikke finnes).