### PR TITLE
Fiks feilende ereg feil + tilgangsmaskinskoder

### DIFF
--- a/src/main/kotlin/no/nav/persondataapi/service/InntektService.kt
+++ b/src/main/kotlin/no/nav/persondataapi/service/InntektService.kt
@@ -39,18 +39,17 @@ class InntektService(
         // Prosesser lønnsinntekt
         val lønnsinntekt = inntektResponse.data?.data
             .orEmpty()
-            .flatMap {
-                historikk ->
-                val arbeidsgiver = eregClient.hentOrganisasjon(historikk.opplysningspliktig)
-
-                val nyeste = historikk.versjoner.nyeste()
+            .flatMap { historikk ->
+                val arbeidsgiver = if (historikk.opplysningspliktig.matches("\\d{9}".toRegex())) {
+                    eregClient.hentOrganisasjon(historikk.opplysningspliktig)
+                } else null
 
                 var respons = historikk.versjoner.nyeste()
                     ?.inntektListe
                     ?.filterIsInstance<Loennsinntekt>()
                     ?.map { loenn ->
                         InntektInformasjon.Lønnsdetaljer(
-                            arbeidsgiver = arbeidsgiver.navn?.sammensattnavn,
+                            arbeidsgiver = arbeidsgiver?.navn?.sammensattnavn ?: historikk.opplysningspliktig,
                             periode = historikk.maaned,
                             arbeidsforhold = "",
                             stillingsprosent = "",

--- a/src/main/kotlin/no/nav/persondataapi/service/InntektService.kt
+++ b/src/main/kotlin/no/nav/persondataapi/service/InntektService.kt
@@ -49,7 +49,7 @@ class InntektService(
                     ?.filterIsInstance<Loennsinntekt>()
                     ?.map { loenn ->
                         InntektInformasjon.Lønnsdetaljer(
-                            arbeidsgiver = arbeidsgiver?.navn?.sammensattnavn ?: historikk.opplysningspliktig,
+                            arbeidsgiver = arbeidsgiver?.navn?.sammensattnavn,
                             periode = historikk.maaned,
                             arbeidsforhold = "",
                             stillingsprosent = "",
@@ -64,7 +64,7 @@ class InntektService(
                         ?.filterIsInstance<Loennsinntekt>()?.isEmpty() == false) {
 
                     respons = listOf(InntektInformasjon.Lønnsdetaljer(
-                        arbeidsgiver = arbeidsgiver?.navn?.sammensattnavn ?: "Ukjent",
+                        arbeidsgiver = null,
                         periode = historikk.maaned,
                         arbeidsforhold = "",
                         stillingsprosent = "",

--- a/src/main/kotlin/no/nav/persondataapi/service/InntektService.kt
+++ b/src/main/kotlin/no/nav/persondataapi/service/InntektService.kt
@@ -64,7 +64,7 @@ class InntektService(
                         ?.filterIsInstance<Loennsinntekt>()?.isEmpty() == false) {
 
                     respons = listOf(InntektInformasjon.Lønnsdetaljer(
-                        arbeidsgiver = arbeidsgiver.navn?.sammensattnavn,
+                        arbeidsgiver = arbeidsgiver?.navn?.sammensattnavn ?: "Ukjent",
                         periode = historikk.maaned,
                         arbeidsforhold = "",
                         stillingsprosent = "",

--- a/src/main/kotlin/no/nav/persondataapi/service/TilgangService.kt
+++ b/src/main/kotlin/no/nav/persondataapi/service/TilgangService.kt
@@ -77,8 +77,8 @@ fun TilgangMaskinResultat.harTilgangMedBasicAdgang(): Boolean {
         "AVVIST_FORTROLIG_ADRESSE" -> return false          // Saksbehandler har ikke tilgang til brukere med fortrolig adresse.
         "AVVIST_GEOGRAFISK" -> return true                  // Saksbehandler har  tilgang til brukerens geografiske område eller enhet.
         "AVVIST_AVDOED" -> return true                      // Saksbehandler har  tilgang til brukere som har vært død i mer enn X måneder.
-        "AVVIST_AVDØD" -> return true                      // Saksbehandler har  tilgang til brukere som har vært død i mer enn X måneder.
-        "AVVIST_SKJERMING" -> return false                  // Saksbehandler har tilgang til Nav-ansatte og andre skjermede brukere.
+        "AVVIST_AVDØD" -> return true                       // Saksbehandler har  tilgang til brukere som har vært død i mer enn X måneder.
+        "AVVIST_SKJERMING" -> return false                  // Saksbehandler har ikke tilgang til Nav-ansatte og andre skjermede brukere.
         "AVVIST_HABILITET" -> return true                   // Saksbehandler har tilgang til data om seg selv eller sine nærstående.
         "AVVIST_VERGE" -> return true                       // Saksbehandler har tilgang om man er registrert som brukerens verge.
         "AVVIST_MANGLENDE_DATA" -> return true              // Om baksystemer kræsjer, anta at man har tilgang

--- a/src/main/kotlin/no/nav/persondataapi/service/TilgangService.kt
+++ b/src/main/kotlin/no/nav/persondataapi/service/TilgangService.kt
@@ -66,6 +66,8 @@ interface TilgangsmaskinClient {
 *   - AVVIST_SKJERMING
 *   - AVVIST_VERGE
 *   - AVVIST_MANGLENDE_DATA
+*   - AVVIST_PERSON_UTLAND
+*   - AVVIST_UKJENT_BOSTED
 *
 * */
 fun TilgangMaskinResultat.harTilgangMedBasicAdgang(): Boolean {
@@ -73,12 +75,15 @@ fun TilgangMaskinResultat.harTilgangMedBasicAdgang(): Boolean {
         "AVVIST_STRENGT_FORTROLIG_ADRESSE" -> return false  // Saksbehandler har ikke tilgang til brukere med strengt fortrolig adresse.
         "AVVIST_STRENGT_FORTROLIG_UTLAND" -> return false   // Saksbehandler har ikke tilgang til brukere med strengt fortrolig adresse i utlandet.
         "AVVIST_FORTROLIG_ADRESSE" -> return false          // Saksbehandler har ikke tilgang til brukere med fortrolig adresse.
-        "AVVIST_GEOGRAFISK" -> return true                 // Saksbehandler har  tilgang til brukerens geografiske område eller enhet.
-        "AVVIST_AVDOED" -> return true                     // Saksbehandler har  tilgang til brukere som har vært død i mer enn X måneder.
-        "AVVIST_SKJERMING" -> return false                   // Saksbehandler har tilgang til Nav-ansatte og andre skjermede brukere.
+        "AVVIST_GEOGRAFISK" -> return true                  // Saksbehandler har  tilgang til brukerens geografiske område eller enhet.
+        "AVVIST_AVDOED" -> return true                      // Saksbehandler har  tilgang til brukere som har vært død i mer enn X måneder.
+        "AVVIST_AVDØD" -> return true                      // Saksbehandler har  tilgang til brukere som har vært død i mer enn X måneder.
+        "AVVIST_SKJERMING" -> return false                  // Saksbehandler har tilgang til Nav-ansatte og andre skjermede brukere.
         "AVVIST_HABILITET" -> return true                   // Saksbehandler har tilgang til data om seg selv eller sine nærstående.
         "AVVIST_VERGE" -> return true                       // Saksbehandler har tilgang om man er registrert som brukerens verge.
         "AVVIST_MANGLENDE_DATA" -> return true              // Om baksystemer kræsjer, anta at man har tilgang
+        "AVVIST_PERSON_UTLAND" -> return true               // Saksbehandler har tilgang om man er registrert i utlandet
+        "AVVIST_UKJENT_BOSTED" -> return true               // Saksbehandler har tilgang om man ikke vet bosted
     }
     return false
 }


### PR DESCRIPTION
Denne PRen fikser en feil vi opplever av og til mot ereg, der vi spør om organisasjonsnumre som ikke er 9 tegn. I de tilfellene vil denne PRen bare fylle ut organisasjonsnavn som ukjent + orgnr.

I tillegg legger vi til to nye avvist-koder fra tilgangsmaskinen, som vi så feilet.