### PR TITLE
Bruk dagnivå for arbeidsforhold i nav-persondata-api

### DIFF
--- a/src/main/kotlin/no/nav/persondataapi/rest/domene/ArbeidsgiverInformasjon.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/domene/ArbeidsgiverInformasjon.kt
@@ -2,6 +2,7 @@ package no.nav.persondataapi.rest.domene
 
 import no.nav.persondataapi.rest.oppslag.Maskert
 import java.time.LocalDate
+import java.time.YearMonth
 
 data class ArbeidsgiverInformasjon(
     val løpendeArbeidsforhold: List<ArbeidsgiverData>,
@@ -12,6 +13,7 @@ data class ArbeidsgiverInformasjon(
         val arbeidsgiver: String,
         @Maskert
         val organisasjonsnummer: String,
+        val ansettelsesperiode: DatoPeriode,
         val ansettelsesDetaljer: List<AnsettelsesDetalj>,
         val id: String,
     )
@@ -24,8 +26,13 @@ data class ArbeidsgiverInformasjon(
         val yrke: String? = null,
     )
 
-    data class ÅpenPeriode(
+    data class DatoPeriode(
         val fom: LocalDate,
         var tom: LocalDate?,
+    )
+
+    data class ÅpenPeriode(
+        val fom: YearMonth,
+        var tom: YearMonth?,
     )
 }

--- a/src/main/kotlin/no/nav/persondataapi/rest/domene/ArbeidsgiverInformasjon.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/domene/ArbeidsgiverInformasjon.kt
@@ -1,7 +1,7 @@
 package no.nav.persondataapi.rest.domene
 
 import no.nav.persondataapi.rest.oppslag.Maskert
-import java.time.YearMonth
+import java.time.LocalDate
 
 data class ArbeidsgiverInformasjon(
     val løpendeArbeidsforhold: List<ArbeidsgiverData>,
@@ -25,7 +25,7 @@ data class ArbeidsgiverInformasjon(
     )
 
     data class ÅpenPeriode(
-        val fom: YearMonth,
-        var tom: YearMonth?,
+        val fom: LocalDate,
+        var tom: LocalDate?,
     )
 }

--- a/src/main/kotlin/no/nav/persondataapi/service/ArbeidsforholdService.kt
+++ b/src/main/kotlin/no/nav/persondataapi/service/ArbeidsforholdService.kt
@@ -107,6 +107,11 @@ class ArbeidsforholdService(
         return ArbeidsgiverInformasjon.ArbeidsgiverData(
             arbeidsgiver = eregDataRespons.orgNummerTilOrgNavn(orgnummer),
             organisasjonsnummer = orgnummer,
+            ansettelsesperiode =
+                ArbeidsgiverInformasjon.DatoPeriode(
+                    fom = periodeForArbeidsforhold.startdato,
+                    tom = periodeForArbeidsforhold.sluttdato,
+                ),
             id = saltedOrgNummer,
             ansettelsesDetaljer =
                 arbeidsforhold.ansettelsesdetaljer.map { ansettelsesdetaljer ->
@@ -116,8 +121,8 @@ class ArbeidsforholdService(
                         antallTimerPrUke = ansettelsesdetaljer.antallTimerPrUke,
                         periode =
                             ArbeidsgiverInformasjon.ÅpenPeriode(
-                                fom = periodeForArbeidsforhold.startdato,
-                                tom = periodeForArbeidsforhold.sluttdato,
+                                fom = ansettelsesdetaljer.rapporteringsmaaneder.fra,
+                                tom = ansettelsesdetaljer.rapporteringsmaaneder.til,
                             ),
                         yrke = ansettelsesdetaljer.yrke.beskrivelse,
                     )

--- a/src/main/kotlin/no/nav/persondataapi/service/ArbeidsforholdService.kt
+++ b/src/main/kotlin/no/nav/persondataapi/service/ArbeidsforholdService.kt
@@ -12,7 +12,6 @@ import no.nav.persondataapi.tracelogging.traceLoggHvisAktivert
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
-import java.time.YearMonth
 
 @Service
 class ArbeidsforholdService(
@@ -101,7 +100,7 @@ class ArbeidsforholdService(
         arbeidsforhold: Arbeidsforhold,
         eregDataRespons: Map<String, EregRespons>,
     ): ArbeidsgiverInformasjon.ArbeidsgiverData {
-        val sluttdatoForArbeidsforhold = arbeidsforhold.ansettelsesperiode.sluttdato
+        val periodeForArbeidsforhold = arbeidsforhold.ansettelsesperiode
 
         val orgnummer = arbeidsforhold.hentOrgNummerTilArbeidssted()
         val saltedOrgNummer = orgnummer.hashCode().toString() + LocalDate.now().dayOfYear.toString()
@@ -117,10 +116,8 @@ class ArbeidsforholdService(
                         antallTimerPrUke = ansettelsesdetaljer.antallTimerPrUke,
                         periode =
                             ArbeidsgiverInformasjon.ÅpenPeriode(
-                                fom = ansettelsesdetaljer.rapporteringsmaaneder.fra,
-                                tom =
-                                    ansettelsesdetaljer.rapporteringsmaaneder.til
-                                        ?: sluttdatoForArbeidsforhold?.let { YearMonth.from(it) },
+                                fom = periodeForArbeidsforhold.startdato,
+                                tom = periodeForArbeidsforhold.sluttdato,
                             ),
                         yrke = ansettelsesdetaljer.yrke.beskrivelse,
                     )

--- a/src/test/kotlin/no/nav/persondataapi/parsing/AaregParseResponsTest.kt
+++ b/src/test/kotlin/no/nav/persondataapi/parsing/AaregParseResponsTest.kt
@@ -60,6 +60,11 @@ class AaregParseResponsTest {
                         null
                 }
             assertTrue(alleAnsattdetaljerHistoriske.isEmpty())
+
+            val json = JsonUtils.toJson(data).toString()
+
+            assertTrue(Regex(""""fom":"\d{4}-\d{2}"""").containsMatchIn(json))
+            assertTrue(Regex(""""tom":"\d{4}-\d{2}"""").containsMatchIn(json))
         }
 }
 

--- a/src/test/kotlin/no/nav/persondataapi/parsing/AaregParseResponsTest.kt
+++ b/src/test/kotlin/no/nav/persondataapi/parsing/AaregParseResponsTest.kt
@@ -63,8 +63,8 @@ class AaregParseResponsTest {
 
             val json = JsonUtils.toJson(data).toString()
 
-            assertTrue(Regex(""""fom":"\d{4}-\d{2}"""").containsMatchIn(json))
-            assertTrue(Regex(""""tom":"\d{4}-\d{2}"""").containsMatchIn(json))
+            assertTrue(Regex(""""fom":"\d{4}-\d{2}-\d{2}"""").containsMatchIn(json))
+            assertTrue(Regex(""""tom":"\d{4}-\d{2}-\d{2}"""").containsMatchIn(json))
         }
 }
 

--- a/src/test/kotlin/no/nav/persondataapi/parsing/AaregParseResponsTest.kt
+++ b/src/test/kotlin/no/nav/persondataapi/parsing/AaregParseResponsTest.kt
@@ -46,25 +46,38 @@ class AaregParseResponsTest {
             assertEquals(1, data.løpendeArbeidsforhold.size)
             assertEquals(3, data.historikk.size)
 
-            // sjekk at kun en ansattDetalj under løpende har null til og med dato
-            val alleAnsattdetaljer =
-                data.løpendeArbeidsforhold.flatMap { it.ansettelsesDetaljer }.filter {
-                    it.periode.tom ==
+            val løpendeArbeidsforholdUtenSluttdato =
+                data.løpendeArbeidsforhold.filter {
+                    it.ansettelsesperiode.tom ==
                         null
                 }
-            assertEquals(1, alleAnsattdetaljer.size)
-            // sjekk at ingenansattDetalj under historisk har null til og med dato
-            val alleAnsattdetaljerHistoriske =
-                data.historikk.flatMap { it.ansettelsesDetaljer }.filter {
-                    it.periode.tom ==
+            assertEquals(1, løpendeArbeidsforholdUtenSluttdato.size)
+            val historiskeArbeidsforholdUtenSluttdato =
+                data.historikk.filter {
+                    it.ansettelsesperiode.tom ==
                         null
                 }
-            assertTrue(alleAnsattdetaljerHistoriske.isEmpty())
+            assertTrue(historiskeArbeidsforholdUtenSluttdato.isEmpty())
 
-            val json = JsonUtils.toJson(data).toString()
+            val json = JsonUtils.toJson(data)
+            val historiskeArbeidsforhold = json.get("historikk")
+            val harAnsettelsesperiodeMedDagnivå =
+                historiskeArbeidsforhold.any {
+                    requireNotNull(it.get("ansettelsesperiode").get("fom").textValue())
+                        .matches(Regex("""\d{4}-\d{2}-\d{2}""")) &&
+                        requireNotNull(it.get("ansettelsesperiode").get("tom").textValue())
+                            .matches(Regex("""\d{4}-\d{2}-\d{2}"""))
+                }
+            val harRapporteringsperiodeMedMånedsnivå =
+                historiskeArbeidsforhold
+                    .flatMap { it.get("ansettelsesDetaljer") }
+                    .any {
+                        requireNotNull(it.get("periode").get("fom").textValue())
+                            .matches(Regex("""\d{4}-\d{2}"""))
+                    }
 
-            assertTrue(Regex(""""fom":"\d{4}-\d{2}-\d{2}"""").containsMatchIn(json))
-            assertTrue(Regex(""""tom":"\d{4}-\d{2}-\d{2}"""").containsMatchIn(json))
+            assertTrue(harAnsettelsesperiodeMedDagnivå)
+            assertTrue(harRapporteringsperiodeMedMånedsnivå)
         }
 }
 

--- a/src/test/kotlin/no/nav/persondataapi/service/ArbeidsforholdServiceTest.kt
+++ b/src/test/kotlin/no/nav/persondataapi/service/ArbeidsforholdServiceTest.kt
@@ -478,6 +478,10 @@ class ArbeidsforholdServiceTest {
             assertEquals(1, data.historikk.size)
             assertEquals(
                 LocalDate.of(2024, 4, 30),
+                data.historikk[0].ansettelsesperiode.tom,
+            )
+            assertEquals(
+                YearMonth.of(2024, 3),
                 data.historikk[0]
                     .ansettelsesDetaljer[0]
                     .periode.tom,
@@ -516,6 +520,10 @@ class ArbeidsforholdServiceTest {
             assertTrue(data.historikk.isEmpty())
             assertEquals(
                 null,
+                data.løpendeArbeidsforhold[0].ansettelsesperiode.tom,
+            )
+            assertEquals(
+                YearMonth.of(2024, 3),
                 data.løpendeArbeidsforhold[0]
                     .ansettelsesDetaljer[0]
                     .periode.tom,
@@ -554,9 +562,65 @@ class ArbeidsforholdServiceTest {
             assertEquals(1, data.historikk.size)
             assertEquals(
                 LocalDate.of(2024, 1, 15),
+                data.historikk[0].ansettelsesperiode.fom,
+            )
+            assertEquals(
+                YearMonth.of(2020, 1),
                 data.historikk[0]
                     .ansettelsesDetaljer[0]
                     .periode.fom,
+            )
+        }
+
+    @Test
+    fun `skal eksponere både ansettelsesperiode og rapporteringsperiode`() =
+        runBlocking {
+            val brukertilgangService = mockk<BrukertilgangService>()
+            val aaregClient = mockk<AaregClient>()
+            val eregClient = mockk<EregClient>()
+
+            val arbeidsforhold =
+                lagArbeidsforhold(
+                    orgnummer = "999888777",
+                    startdato = LocalDate.of(2024, 1, 15),
+                    sluttdato = LocalDate.of(2024, 4, 30),
+                    rapporteringsmaanederTil = YearMonth.of(2024, 3),
+                )
+
+            every { brukertilgangService.harSaksbehandlerTilgangTilPersonIdent(any()) } returns true
+            every { aaregClient.hentArbeidsforhold(any()) } returns
+                AaregDataResultat(
+                    data = listOf(arbeidsforhold),
+                    statusCode = 200,
+                    errorMessage = null,
+                )
+            every { eregClient.hentOrganisasjon(any()) } returns lagEregRespons("999888777", "Test Bedrift AS")
+
+            val service = ArbeidsforholdService(aaregClient, eregClient, brukertilgangService)
+            val resultat = service.hentArbeidsforholdForPerson(PersonIdent("12345678901"))
+
+            assertTrue(resultat is ArbeidsforholdResultat.Success)
+            val data = (resultat as ArbeidsforholdResultat.Success).data
+            assertEquals(1, data.historikk.size)
+            assertEquals(
+                LocalDate.of(2024, 1, 15),
+                data.historikk[0].ansettelsesperiode.fom,
+            )
+            assertEquals(
+                LocalDate.of(2024, 4, 30),
+                data.historikk[0].ansettelsesperiode.tom,
+            )
+            assertEquals(
+                YearMonth.of(2020, 1),
+                data.historikk[0]
+                    .ansettelsesDetaljer[0]
+                    .periode.fom,
+            )
+            assertEquals(
+                YearMonth.of(2024, 3),
+                data.historikk[0]
+                    .ansettelsesDetaljer[0]
+                    .periode.tom,
             )
         }
 

--- a/src/test/kotlin/no/nav/persondataapi/service/ArbeidsforholdServiceTest.kt
+++ b/src/test/kotlin/no/nav/persondataapi/service/ArbeidsforholdServiceTest.kt
@@ -448,7 +448,7 @@ class ArbeidsforholdServiceTest {
         }
 
     @Test
-    fun `skal bruke rapporteringsmaaneder til naar den finnes`() =
+    fun `skal bruke sluttdato fra ansettelsesperiode selv om rapporteringsmaaneder til finnes`() =
         runBlocking {
             val brukertilgangService = mockk<BrukertilgangService>()
             val aaregClient = mockk<AaregClient>()
@@ -477,7 +477,7 @@ class ArbeidsforholdServiceTest {
             val data = (resultat as ArbeidsforholdResultat.Success).data
             assertEquals(1, data.historikk.size)
             assertEquals(
-                YearMonth.of(2024, 3),
+                LocalDate.of(2024, 4, 30),
                 data.historikk[0]
                     .ansettelsesDetaljer[0]
                     .periode.tom,
@@ -515,7 +515,7 @@ class ArbeidsforholdServiceTest {
             assertEquals(1, data.løpendeArbeidsforhold.size)
             assertTrue(data.historikk.isEmpty())
             assertEquals(
-                YearMonth.of(2024, 3),
+                null,
                 data.løpendeArbeidsforhold[0]
                     .ansettelsesDetaljer[0]
                     .periode.tom,
@@ -523,7 +523,7 @@ class ArbeidsforholdServiceTest {
         }
 
     @Test
-    fun `skal bruke sluttdato som fallback naar rapporteringsmaaneder til mangler`() =
+    fun `skal bruke startdato fra ansettelsesperiode selv om rapporteringsmaaneder bare har månedsnivå`() =
         runBlocking {
             val brukertilgangService = mockk<BrukertilgangService>()
             val aaregClient = mockk<AaregClient>()
@@ -532,6 +532,7 @@ class ArbeidsforholdServiceTest {
             val arbeidsforhold =
                 lagArbeidsforhold(
                     orgnummer = "999888777",
+                    startdato = LocalDate.of(2024, 1, 15),
                     sluttdato = LocalDate.of(2024, 4, 30),
                     rapporteringsmaanederTil = null,
                 )
@@ -552,10 +553,10 @@ class ArbeidsforholdServiceTest {
             val data = (resultat as ArbeidsforholdResultat.Success).data
             assertEquals(1, data.historikk.size)
             assertEquals(
-                YearMonth.of(2024, 4),
+                LocalDate.of(2024, 1, 15),
                 data.historikk[0]
                     .ansettelsesDetaljer[0]
-                    .periode.tom,
+                    .periode.fom,
             )
         }
 
@@ -603,6 +604,7 @@ class ArbeidsforholdServiceTest {
 // Hjelpefunksjoner for å lage testdata
 private fun lagArbeidsforhold(
     orgnummer: String,
+    startdato: LocalDate = LocalDate.of(2020, 1, 1),
     sluttdato: LocalDate?,
     ansettelsesType: String = "Ordinær",
     stillingsprosent: Double? = 100.0,
@@ -650,7 +652,7 @@ private fun lagArbeidsforhold(
             ),
         ansettelsesperiode =
             Ansettelsesperiode(
-                startdato = LocalDate.of(2020, 1, 1),
+                startdato = startdato,
                 sluttdato = sluttdato,
                 sluttaarsak = null,
                 varsling = null,

--- a/src/test/kotlin/no/nav/persondataapi/service/ArbeidsforholdServiceTest.kt
+++ b/src/test/kotlin/no/nav/persondataapi/service/ArbeidsforholdServiceTest.kt
@@ -446,6 +446,158 @@ class ArbeidsforholdServiceTest {
             assertTrue(data.løpendeArbeidsforhold.all { it.organisasjonsnummer == "999888777" })
             assertTrue(data.historikk.all { it.organisasjonsnummer == "999888777" })
         }
+
+    @Test
+    fun `skal bruke rapporteringsmaaneder til naar den finnes`() =
+        runBlocking {
+            val brukertilgangService = mockk<BrukertilgangService>()
+            val aaregClient = mockk<AaregClient>()
+            val eregClient = mockk<EregClient>()
+
+            val arbeidsforhold =
+                lagArbeidsforhold(
+                    orgnummer = "999888777",
+                    sluttdato = LocalDate.of(2024, 4, 30),
+                    rapporteringsmaanederTil = YearMonth.of(2024, 3),
+                )
+
+            every { brukertilgangService.harSaksbehandlerTilgangTilPersonIdent(any()) } returns true
+            every { aaregClient.hentArbeidsforhold(any()) } returns
+                AaregDataResultat(
+                    data = listOf(arbeidsforhold),
+                    statusCode = 200,
+                    errorMessage = null,
+                )
+            every { eregClient.hentOrganisasjon(any()) } returns lagEregRespons("999888777", "Test Bedrift AS")
+
+            val service = ArbeidsforholdService(aaregClient, eregClient, brukertilgangService)
+            val resultat = service.hentArbeidsforholdForPerson(PersonIdent("12345678901"))
+
+            assertTrue(resultat is ArbeidsforholdResultat.Success)
+            val data = (resultat as ArbeidsforholdResultat.Success).data
+            assertEquals(1, data.historikk.size)
+            assertEquals(
+                YearMonth.of(2024, 3),
+                data.historikk[0]
+                    .ansettelsesDetaljer[0]
+                    .periode.tom,
+            )
+        }
+
+    @Test
+    fun `skal klassifisere som loepende selv om rapporteringsmaaneder til er satt`() =
+        runBlocking {
+            val brukertilgangService = mockk<BrukertilgangService>()
+            val aaregClient = mockk<AaregClient>()
+            val eregClient = mockk<EregClient>()
+
+            val arbeidsforhold =
+                lagArbeidsforhold(
+                    orgnummer = "999888777",
+                    sluttdato = null,
+                    rapporteringsmaanederTil = YearMonth.of(2024, 3),
+                )
+
+            every { brukertilgangService.harSaksbehandlerTilgangTilPersonIdent(any()) } returns true
+            every { aaregClient.hentArbeidsforhold(any()) } returns
+                AaregDataResultat(
+                    data = listOf(arbeidsforhold),
+                    statusCode = 200,
+                    errorMessage = null,
+                )
+            every { eregClient.hentOrganisasjon(any()) } returns lagEregRespons("999888777", "Test Bedrift AS")
+
+            val service = ArbeidsforholdService(aaregClient, eregClient, brukertilgangService)
+            val resultat = service.hentArbeidsforholdForPerson(PersonIdent("12345678901"))
+
+            assertTrue(resultat is ArbeidsforholdResultat.Success)
+            val data = (resultat as ArbeidsforholdResultat.Success).data
+            assertEquals(1, data.løpendeArbeidsforhold.size)
+            assertTrue(data.historikk.isEmpty())
+            assertEquals(
+                YearMonth.of(2024, 3),
+                data.løpendeArbeidsforhold[0]
+                    .ansettelsesDetaljer[0]
+                    .periode.tom,
+            )
+        }
+
+    @Test
+    fun `skal bruke sluttdato som fallback naar rapporteringsmaaneder til mangler`() =
+        runBlocking {
+            val brukertilgangService = mockk<BrukertilgangService>()
+            val aaregClient = mockk<AaregClient>()
+            val eregClient = mockk<EregClient>()
+
+            val arbeidsforhold =
+                lagArbeidsforhold(
+                    orgnummer = "999888777",
+                    sluttdato = LocalDate.of(2024, 4, 30),
+                    rapporteringsmaanederTil = null,
+                )
+
+            every { brukertilgangService.harSaksbehandlerTilgangTilPersonIdent(any()) } returns true
+            every { aaregClient.hentArbeidsforhold(any()) } returns
+                AaregDataResultat(
+                    data = listOf(arbeidsforhold),
+                    statusCode = 200,
+                    errorMessage = null,
+                )
+            every { eregClient.hentOrganisasjon(any()) } returns lagEregRespons("999888777", "Test Bedrift AS")
+
+            val service = ArbeidsforholdService(aaregClient, eregClient, brukertilgangService)
+            val resultat = service.hentArbeidsforholdForPerson(PersonIdent("12345678901"))
+
+            assertTrue(resultat is ArbeidsforholdResultat.Success)
+            val data = (resultat as ArbeidsforholdResultat.Success).data
+            assertEquals(1, data.historikk.size)
+            assertEquals(
+                YearMonth.of(2024, 4),
+                data.historikk[0]
+                    .ansettelsesDetaljer[0]
+                    .periode.tom,
+            )
+        }
+
+    @Test
+    fun `skal beholde baade loepende og historiske arbeidsforhold for samme arbeidsgiver`() =
+        runBlocking {
+            val brukertilgangService = mockk<BrukertilgangService>()
+            val aaregClient = mockk<AaregClient>()
+            val eregClient = mockk<EregClient>()
+
+            val løpendeArbeidsforhold =
+                lagArbeidsforhold(
+                    orgnummer = "999888777",
+                    sluttdato = null,
+                    rapporteringsmaanederTil = null,
+                )
+            val historiskArbeidsforhold =
+                lagArbeidsforhold(
+                    orgnummer = "999888777",
+                    sluttdato = LocalDate.of(2023, 12, 31),
+                    rapporteringsmaanederTil = YearMonth.of(2023, 11),
+                )
+
+            every { brukertilgangService.harSaksbehandlerTilgangTilPersonIdent(any()) } returns true
+            every { aaregClient.hentArbeidsforhold(any()) } returns
+                AaregDataResultat(
+                    data = listOf(løpendeArbeidsforhold, historiskArbeidsforhold),
+                    statusCode = 200,
+                    errorMessage = null,
+                )
+            every { eregClient.hentOrganisasjon(any()) } returns lagEregRespons("999888777", "Test Bedrift AS")
+
+            val service = ArbeidsforholdService(aaregClient, eregClient, brukertilgangService)
+            val resultat = service.hentArbeidsforholdForPerson(PersonIdent("12345678901"))
+
+            assertTrue(resultat is ArbeidsforholdResultat.Success)
+            val data = (resultat as ArbeidsforholdResultat.Success).data
+            assertEquals(1, data.løpendeArbeidsforhold.size)
+            assertEquals(1, data.historikk.size)
+            assertEquals("999888777", data.løpendeArbeidsforhold[0].organisasjonsnummer)
+            assertEquals("999888777", data.historikk[0].organisasjonsnummer)
+        }
 }
 
 // Hjelpefunksjoner for å lage testdata
@@ -456,6 +608,7 @@ private fun lagArbeidsforhold(
     stillingsprosent: Double? = 100.0,
     timerPrUke: Double? = 37.5,
     yrkeBeskrivelse: String = "Konsulent",
+    rapporteringsmaanederTil: YearMonth? = null,
 ): Arbeidsforhold =
     Arbeidsforhold(
         id = "test-id",
@@ -517,7 +670,7 @@ private fun lagArbeidsforhold(
                     rapporteringsmaaneder =
                         Rapporteringsmaaneder(
                             fra = YearMonth.of(2020, 1),
-                            til = null,
+                            til = rapporteringsmaanederTil,
                         ),
                     sporingsinformasjon = null,
                 ),


### PR DESCRIPTION
## Oppsummering
- legger til kontraktstester som låser klassifisering av arbeidsforhold og serialisert periodeformat til ønsket backend-adferd
- endrer arbeidsforholdsperioder på wire-formatet fra månedsnivå til LocalDate basert direkte på ansettelsesperiode.startdato og ansettelsesperiode.sluttdato
- beholder rapporteringsmaaneder som intern metadata på månedsnivå i stedet for å overlesse dem inn i den eksterne arbeidsforholdskontrakten

## Verifisering
- ./gradlew test build