### PR TITLE
feat: returner gammel Map-format for familemedlemmer når watson-sok-v-1-2 er AV

### DIFF
--- a/src/main/kotlin/no/nav/persondataapi/rest/domene/PersonInformasjonV1Dto.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/domene/PersonInformasjonV1Dto.kt
@@ -1,0 +1,36 @@
+package no.nav.persondataapi.rest.domene
+
+/**
+ * V1-responsformat for personopplysninger — brukes når feature-flagget watson-sok-v-1-2 er AV.
+ *
+ * Tilsvarer PersonInformasjon, men familemedlemmer er representert som Map<ident, rolle>
+ * istedenfor List<Familiemedlem>.
+ */
+data class PersonInformasjonV1Dto(
+    val aktørId: String?,
+    val familemedlemmer: Map<String, String>,
+    val statsborgerskap: List<String>,
+    val navn: PersonInformasjon.Navn,
+    val adresse: PersonInformasjon.Bostedsadresse?,
+    val sivilstand: String?,
+    val alder: Int,
+    val adressebeskyttelse: PersonInformasjon.Skjerming,
+    val fødselsdato: String,
+    val dødsdato: String?,
+    val navKontor: PersonInformasjon.NavKontor?,
+)
+
+fun PersonInformasjon.tilV1Format(): PersonInformasjonV1Dto =
+    PersonInformasjonV1Dto(
+        aktørId = aktørId,
+        familemedlemmer = familemedlemmer.associate { it.ident to it.rolle },
+        statsborgerskap = statsborgerskap,
+        navn = navn,
+        adresse = adresse,
+        sivilstand = sivilstand,
+        alder = alder,
+        adressebeskyttelse = adressebeskyttelse,
+        fødselsdato = fødselsdato,
+        dødsdato = dødsdato,
+        navKontor = navKontor,
+    )

--- a/src/main/kotlin/no/nav/persondataapi/rest/domene/PersonInformasjonV1Dto.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/domene/PersonInformasjonV1Dto.kt
@@ -3,8 +3,8 @@ package no.nav.persondataapi.rest.domene
 /**
  * V1-responsformat for personopplysninger — brukes når feature-flagget watson-sok-v-1-2 er AV.
  *
- * Tilsvarer PersonInformasjon, men familemedlemmer er representert som Map<ident, rolle>
- * istedenfor List<Familiemedlem>.
+ * Tilsvarer PersonInformasjon, men `familemedlemmer` er representert som `Map<String, String>` (ident → rolle)
+ * istedenfor `List<Familiemedlem>`.
  */
 data class PersonInformasjonV1Dto(
     val aktørId: String?,

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerController.kt
@@ -10,8 +10,11 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import kotlinx.coroutines.runBlocking
 import no.nav.persondataapi.responstracing.LOGG_HEADER
 import no.nav.persondataapi.rest.domene.PersonInformasjon
+import no.nav.persondataapi.rest.domene.tilV1Format
 import no.nav.persondataapi.service.PersonopplysningerResultat
 import no.nav.persondataapi.service.PersonopplysningerService
+import no.nav.persondataapi.unleash.FeatureToggleService
+import no.nav.persondataapi.unleash.Toggle
 import no.nav.security.token.support.core.api.Protected
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -26,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 @Tag(name = "Personopplysninger", description = "Endepunkter for oppslag av personopplysninger")
 class PersonopplysningerController(
     private val personopplysningerService: PersonopplysningerService,
+    private val featureToggleService: FeatureToggleService,
 ) {
     @Protected
     @PostMapping
@@ -95,14 +99,16 @@ class PersonopplysningerController(
     fun hentPersonopplysninger(
         @RequestBody dto: OppslagRequestDto,
         @RequestHeader(name = LOGG_HEADER, required = false) traceHeader: String?,
-    ): ResponseEntity<OppslagResponseDto<PersonInformasjon>> =
+    ): ResponseEntity<*> =
         runBlocking {
             val logResponsAktivert = traceHeader?.toBoolean() ?: false
             val resultat = personopplysningerService.hentPersonopplysningerForPerson(dto.ident, logResponsAktivert)
 
             when (resultat) {
                 is PersonopplysningerResultat.Success -> {
-                    ResponseEntity.ok(OppslagResponseDto(data = resultat.data))
+                    val nyStruktur = featureToggleService.isEnabled(Toggle.WATSON_SOK_V_1_2)
+                    val data = if (nyStruktur) resultat.data else resultat.data.tilV1Format()
+                    ResponseEntity.ok(OppslagResponseDto(data = data))
                 }
 
                 is PersonopplysningerResultat.IngenTilgang -> {

--- a/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerController.kt
+++ b/src/main/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerController.kt
@@ -9,7 +9,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import kotlinx.coroutines.runBlocking
 import no.nav.persondataapi.responstracing.LOGG_HEADER
-import no.nav.persondataapi.rest.domene.PersonInformasjon
 import no.nav.persondataapi.rest.domene.tilV1Format
 import no.nav.persondataapi.service.PersonopplysningerResultat
 import no.nav.persondataapi.service.PersonopplysningerService
@@ -99,7 +98,7 @@ class PersonopplysningerController(
     fun hentPersonopplysninger(
         @RequestBody dto: OppslagRequestDto,
         @RequestHeader(name = LOGG_HEADER, required = false) traceHeader: String?,
-    ): ResponseEntity<*> =
+    ): ResponseEntity<OppslagResponseDto<Any>> =
         runBlocking {
             val logResponsAktivert = traceHeader?.toBoolean() ?: false
             val resultat = personopplysningerService.hentPersonopplysningerForPerson(dto.ident, logResponsAktivert)
@@ -107,26 +106,26 @@ class PersonopplysningerController(
             when (resultat) {
                 is PersonopplysningerResultat.Success -> {
                     val nyStruktur = featureToggleService.isEnabled(Toggle.WATSON_SOK_V_1_2)
-                    val data = if (nyStruktur) resultat.data else resultat.data.tilV1Format()
+                    val data: Any = if (nyStruktur) resultat.data else resultat.data.tilV1Format()
                     ResponseEntity.ok(OppslagResponseDto(data = data))
                 }
 
                 is PersonopplysningerResultat.IngenTilgang -> {
-                    ResponseEntity(
+                    ResponseEntity<OppslagResponseDto<Any>>(
                         OppslagResponseDto(error = "Ingen tilgang", data = null),
                         HttpStatus.FORBIDDEN,
                     )
                 }
 
                 is PersonopplysningerResultat.PersonIkkeFunnet -> {
-                    ResponseEntity(
+                    ResponseEntity<OppslagResponseDto<Any>>(
                         OppslagResponseDto(error = "Person ikke funnet", data = null),
                         HttpStatus.NOT_FOUND,
                     )
                 }
 
                 is PersonopplysningerResultat.FeilIBaksystem -> {
-                    ResponseEntity(
+                    ResponseEntity<OppslagResponseDto<Any>>(
                         OppslagResponseDto(error = "Feil i baksystem", data = null),
                         HttpStatus.BAD_GATEWAY,
                     )

--- a/src/test/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerControllerTest.kt
+++ b/src/test/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerControllerTest.kt
@@ -54,7 +54,7 @@ class PersonopplysningerControllerTest {
             val respons = controller.hentPersonopplysninger(OppslagRequestDto(PersonIdent("12345678901")), null)
 
             assertEquals(HttpStatus.OK, respons.statusCode)
-            val data = (respons.body as OppslagResponseDto<*>).data
+            val data = respons.body?.data
             assertInstanceOf(PersonInformasjon::class.java, data)
             val personInfo = data as PersonInformasjon
             assertEquals(1, personInfo.familemedlemmer.size)
@@ -73,7 +73,7 @@ class PersonopplysningerControllerTest {
             val respons = controller.hentPersonopplysninger(OppslagRequestDto(PersonIdent("12345678901")), null)
 
             assertEquals(HttpStatus.OK, respons.statusCode)
-            val data = (respons.body as OppslagResponseDto<*>).data
+            val data = respons.body?.data
             assertInstanceOf(PersonInformasjonV1Dto::class.java, data)
             val v1Dto = data as PersonInformasjonV1Dto
             assertEquals(mapOf("11111111111" to "BARN"), v1Dto.familemedlemmer)

--- a/src/test/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerControllerTest.kt
+++ b/src/test/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerControllerTest.kt
@@ -1,0 +1,105 @@
+package no.nav.persondataapi.rest.oppslag
+
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.persondataapi.rest.domene.PersonIdent
+import no.nav.persondataapi.rest.domene.PersonInformasjon
+import no.nav.persondataapi.rest.domene.PersonInformasjonV1Dto
+import no.nav.persondataapi.service.PersonopplysningerResultat
+import no.nav.persondataapi.service.PersonopplysningerService
+import no.nav.persondataapi.unleash.FeatureToggleService
+import no.nav.persondataapi.unleash.Toggle
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+
+class PersonopplysningerControllerTest {
+    private val personopplysningerService = mockk<PersonopplysningerService>()
+    private val featureToggleService = mockk<FeatureToggleService>()
+    private val controller = PersonopplysningerController(personopplysningerService, featureToggleService)
+
+    private val etFamiliemedlem =
+        PersonInformasjon.Familiemedlem(
+            ident = "11111111111",
+            rolle = "BARN",
+            fornavn = "Liten",
+            etternavn = "Nordmann",
+        )
+
+    private val personopplysninger =
+        PersonInformasjon(
+            aktørId = "12345678901",
+            familemedlemmer = listOf(etFamiliemedlem),
+            statsborgerskap = listOf("Norge"),
+            navn = PersonInformasjon.Navn(fornavn = "Ola", mellomnavn = null, etternavn = "Nordmann"),
+            adresse = null,
+            sivilstand = null,
+            alder = 40,
+            adressebeskyttelse = PersonInformasjon.Skjerming.UGRADERT,
+            fødselsdato = "1984-01-01",
+            dødsdato = null,
+            navKontor = null,
+        )
+
+    @Test
+    fun `returnerer ny List-struktur for familemedlemmer når feature-flagg er PÅ`() =
+        runBlocking {
+            every { featureToggleService.isEnabled(Toggle.WATSON_SOK_V_1_2) } returns true
+            coEvery { personopplysningerService.hentPersonopplysningerForPerson(any(), any()) } returns
+                PersonopplysningerResultat.Success(personopplysninger)
+
+            val respons = controller.hentPersonopplysninger(OppslagRequestDto(PersonIdent("12345678901")), null)
+
+            assertEquals(HttpStatus.OK, respons.statusCode)
+            val data = respons.body?.data
+            assertInstanceOf(PersonInformasjon::class.java, data)
+            val personInfo = data as PersonInformasjon
+            assertEquals(1, personInfo.familemedlemmer.size)
+            assertEquals("11111111111", personInfo.familemedlemmer[0].ident)
+            assertEquals("BARN", personInfo.familemedlemmer[0].rolle)
+            assertEquals("Liten", personInfo.familemedlemmer[0].fornavn)
+        }
+
+    @Test
+    fun `returnerer gammel Map-struktur for familemedlemmer når feature-flagg er AV`() =
+        runBlocking {
+            every { featureToggleService.isEnabled(Toggle.WATSON_SOK_V_1_2) } returns false
+            coEvery { personopplysningerService.hentPersonopplysningerForPerson(any(), any()) } returns
+                PersonopplysningerResultat.Success(personopplysninger)
+
+            val respons = controller.hentPersonopplysninger(OppslagRequestDto(PersonIdent("12345678901")), null)
+
+            assertEquals(HttpStatus.OK, respons.statusCode)
+            val data = respons.body?.data
+            assertInstanceOf(PersonInformasjonV1Dto::class.java, data)
+            val v1Dto = data as PersonInformasjonV1Dto
+            assertEquals(mapOf("11111111111" to "BARN"), v1Dto.familemedlemmer)
+        }
+
+    @Test
+    fun `returnerer 403 ved IngenTilgang uavhengig av feature-flagg`() =
+        runBlocking {
+            every { featureToggleService.isEnabled(any()) } returns false
+            coEvery { personopplysningerService.hentPersonopplysningerForPerson(any(), any()) } returns
+                PersonopplysningerResultat.IngenTilgang
+
+            val respons = controller.hentPersonopplysninger(OppslagRequestDto(PersonIdent("12345678901")), null)
+
+            assertEquals(HttpStatus.FORBIDDEN, respons.statusCode)
+        }
+
+    @Test
+    fun `returnerer 404 ved PersonIkkeFunnet uavhengig av feature-flagg`() =
+        runBlocking {
+            every { featureToggleService.isEnabled(any()) } returns false
+            coEvery { personopplysningerService.hentPersonopplysningerForPerson(any(), any()) } returns
+                PersonopplysningerResultat.PersonIkkeFunnet
+
+            val respons = controller.hentPersonopplysninger(OppslagRequestDto(PersonIdent("12345678901")), null)
+
+            assertEquals(HttpStatus.NOT_FOUND, respons.statusCode)
+        }
+}

--- a/src/test/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerControllerTest.kt
+++ b/src/test/kotlin/no/nav/persondataapi/rest/oppslag/PersonopplysningerControllerTest.kt
@@ -54,7 +54,7 @@ class PersonopplysningerControllerTest {
             val respons = controller.hentPersonopplysninger(OppslagRequestDto(PersonIdent("12345678901")), null)
 
             assertEquals(HttpStatus.OK, respons.statusCode)
-            val data = respons.body?.data
+            val data = (respons.body as OppslagResponseDto<*>).data
             assertInstanceOf(PersonInformasjon::class.java, data)
             val personInfo = data as PersonInformasjon
             assertEquals(1, personInfo.familemedlemmer.size)
@@ -73,7 +73,7 @@ class PersonopplysningerControllerTest {
             val respons = controller.hentPersonopplysninger(OppslagRequestDto(PersonIdent("12345678901")), null)
 
             assertEquals(HttpStatus.OK, respons.statusCode)
-            val data = respons.body?.data
+            val data = (respons.body as OppslagResponseDto<*>).data
             assertInstanceOf(PersonInformasjonV1Dto::class.java, data)
             val v1Dto = data as PersonInformasjonV1Dto
             assertEquals(mapOf("11111111111" to "BARN"), v1Dto.familemedlemmer)


### PR DESCRIPTION
## Hva er gjort

Implementerer feature-toggle-støtte for den nye familiemedlemmer-strukturen i API-responsen.

### Endringer

- **`PersonInformasjonV1Dto`** — ny response-DTO med `familemedlemmer: Map<String, String>` (gammel format) + extension-funksjon `tilV1Format()`
- **`PersonopplysningerController`** — sjekker `Toggle.WATSON_SOK_V_1_2`:
  - Flag **PÅ** → returnerer `PersonInformasjon` med ny `List<Familiemedlem>`-struktur
  - Flag **AV** → returnerer `PersonInformasjonV1Dto` med gammel `Map<String, String>`-struktur
- PDL-bolk-kall (`hentPersonBolk`) kjøres alltid uavhengig av flagget
- **`PersonopplysningerControllerTest`** — 4 tester som verifiserer toggle-oppførsel

### Sammenheng

watson-sok PR #264 (`feature/oppdater-familiemedlemmer-api`) forventer den nye strukturen. watson-sok sin feature-toggle-support-branch (`feature/familiemedlemmer-feature-toggle-support`) håndterer begge formater og merges inn i #264.