### PR TITLE
fix: bruk mock-oauth2-server for JWT-validering i lokalmiljø

### DIFF
--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -32,8 +32,8 @@ management:
 no.nav.security.jwt:
   issuer:
     azuread:
-      discoveryurl: "https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/v2.0/.well-known/openid-configuration"
-      accepted_audience: "f99254b7-a630-48fe-a21a-21989eca6f4b"
+      discoveryurl: http://localhost:8090/azuread/.well-known/openid-configuration
+      accepted_audience: nav-persondata-api
 
 VALKEY_HOST_NAV_PERSONDATA_API: localhost
 VALKEY_PORT_NAV_PERSONDATA_API: 6379

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -32,7 +32,7 @@ management:
 no.nav.security.jwt:
   issuer:
     azuread:
-      discoveryurl: http://localhost:8090/azuread/.well-known/openid-configuration
+      discoveryurl: ${AZURE_APP_WELL_KNOWN_URL:http://localhost:8090/azuread/.well-known/openid-configuration}
       accepted_audience: nav-persondata-api
 
 VALKEY_HOST_NAV_PERSONDATA_API: localhost

--- a/src/test/kotlin/no/nav/persondataapi/test/LocalWireMockSmokeTest.kt
+++ b/src/test/kotlin/no/nav/persondataapi/test/LocalWireMockSmokeTest.kt
@@ -38,6 +38,14 @@ class LocalWireMockSmokeTest {
                 WireMockConfiguration.wireMockConfig().dynamicPort().usingFilesUnderDirectory("src/test/resources"),
             ).apply {
                 start()
+                stubFor(
+                    WireMock.get(WireMock.urlPathEqualTo("/azuread/.well-known/openid-configuration"))
+                        .willReturn(
+                            WireMock.okJson(
+                                """{"issuer":"http://localhost:${port()}/azuread","jwks_uri":"http://localhost:${port()}/azuread/jwks","token_endpoint":"http://localhost:${port()}/azuread/token","authorization_endpoint":"http://localhost:${port()}/azuread/authorize","response_types_supported":["code"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"]}""",
+                            ),
+                        ),
+                )
             }
 
         @JvmStatic
@@ -45,6 +53,7 @@ class LocalWireMockSmokeTest {
         fun props(registry: DynamicPropertyRegistry) {
             val port = wiremock.port()
             registry.add("WIREMOCK_PORT") { port.toString() }
+            registry.add("AZURE_APP_WELL_KNOWN_URL") { "http://localhost:$port/azuread/.well-known/openid-configuration" }
             registry.add("AZURE_OPENID_CONFIG_TOKEN_ENDPOINT") { "http://localhost:$port/oauth2/token" }
             registry.add("NAIS_TOKEN_EXCHANGE_ENDPOINT") { "http://localhost:$port/api/v1/token/exchange" }
             registry.add("PDL_URL") { "http://localhost:$port/pdl/graphql" }

--- a/src/test/kotlin/no/nav/persondataapi/test/LocalWireMockSmokeTest.kt
+++ b/src/test/kotlin/no/nav/persondataapi/test/LocalWireMockSmokeTest.kt
@@ -46,6 +46,10 @@ class LocalWireMockSmokeTest {
                             ),
                         ),
                 )
+                stubFor(
+                    WireMock.get(WireMock.urlPathEqualTo("/azuread/jwks"))
+                        .willReturn(WireMock.okJson("""{"keys":[]}""")),
+                )
             }
 
         @JvmStatic

--- a/src/test/kotlin/no/nav/persondataapi/test/LocalWireMockSmokeTest.kt
+++ b/src/test/kotlin/no/nav/persondataapi/test/LocalWireMockSmokeTest.kt
@@ -39,7 +39,8 @@ class LocalWireMockSmokeTest {
             ).apply {
                 start()
                 stubFor(
-                    WireMock.get(WireMock.urlPathEqualTo("/azuread/.well-known/openid-configuration"))
+                    WireMock
+                        .get(WireMock.urlPathEqualTo("/azuread/.well-known/openid-configuration"))
                         .willReturn(
                             WireMock.okJson(
                                 """{"issuer":"http://localhost:${port()}/azuread","jwks_uri":"http://localhost:${port()}/azuread/jwks","token_endpoint":"http://localhost:${port()}/azuread/token","authorization_endpoint":"http://localhost:${port()}/azuread/authorize","response_types_supported":["code"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"]}""",
@@ -47,7 +48,8 @@ class LocalWireMockSmokeTest {
                         ),
                 )
                 stubFor(
-                    WireMock.get(WireMock.urlPathEqualTo("/azuread/jwks"))
+                    WireMock
+                        .get(WireMock.urlPathEqualTo("/azuread/jwks"))
                         .willReturn(WireMock.okJson("""{"keys":[]}""")),
                 )
             }
@@ -57,7 +59,9 @@ class LocalWireMockSmokeTest {
         fun props(registry: DynamicPropertyRegistry) {
             val port = wiremock.port()
             registry.add("WIREMOCK_PORT") { port.toString() }
-            registry.add("AZURE_APP_WELL_KNOWN_URL") { "http://localhost:$port/azuread/.well-known/openid-configuration" }
+            registry.add(
+                "AZURE_APP_WELL_KNOWN_URL",
+            ) { "http://localhost:$port/azuread/.well-known/openid-configuration" }
             registry.add("AZURE_OPENID_CONFIG_TOKEN_ENDPOINT") { "http://localhost:$port/oauth2/token" }
             registry.add("NAIS_TOKEN_EXCHANGE_ENDPOINT") { "http://localhost:$port/api/v1/token/exchange" }
             registry.add("PDL_URL") { "http://localhost:$port/pdl/graphql" }


### PR DESCRIPTION
## Problem

`application-local.yaml` pekte på ekte Azure AD for tokenvalidering. Tokens fra mock-oauth2-server ble dermed avvist med `401 Unauthorized`.

## Endring

Setter `discoveryurl` til mock-oauth2-server på port 8090 og `accepted_audience` til `nav-persondata-api` — samme mønster som `watson-admin-api` allerede bruker.

Oppdaget da watson-sok ble lagt til i Tilt-konfigen: navikt/watson-developer#21