### PR TITLE
SEARCH-45: Utvid tidsvindu fra 10 til 13 år

### DIFF
--- a/src/main/kotlin/no/nav/persondataapi/integrasjon/aap/meldekort/client/AapClient.kt
+++ b/src/main/kotlin/no/nav/persondataapi/integrasjon/aap/meldekort/client/AapClient.kt
@@ -40,7 +40,7 @@ class AapClient(
         personIdent: PersonIdent,
         utvidet: Boolean,
     ): AapMeldekortRespons {
-        val antallÅr: Long = if (utvidet) 10 else 3
+        val antallÅr: Long = if (utvidet) 13 else 3
         val oboToken = tokenService.getServiceToken(SCOPE.AAP_SCOPE)
         return runCatching {
             metrics.timer(operationName).recordCallable {

--- a/src/main/kotlin/no/nav/persondataapi/integrasjon/dagpenger/datadeling/DagpengerDatadelingClient.kt
+++ b/src/main/kotlin/no/nav/persondataapi/integrasjon/dagpenger/datadeling/DagpengerDatadelingClient.kt
@@ -40,7 +40,7 @@ class DagpengerDatadelingClient(
         personIdent: PersonIdent,
         utvidet: Boolean,
     ): DagpengerMeldekortRespons {
-        val antallÅr: Long = if (utvidet) 10 else 3
+        val antallÅr: Long = if (utvidet) 13 else 3
         val oboToken = tokenService.getServiceToken(SCOPE.DP_DATADELING_SCOPE)
         return runCatching {
             metrics.timer(operationName).recordCallable {

--- a/src/main/kotlin/no/nav/persondataapi/integrasjon/utbetaling/client/UtbetalingClient.kt
+++ b/src/main/kotlin/no/nav/persondataapi/integrasjon/utbetaling/client/UtbetalingClient.kt
@@ -44,7 +44,7 @@ class UtbetalingClient(
                 metrics
                     .timer(operationName)
                     .recordCallable {
-                        val antallÅr: Long = if (utvidet) 10 else 3
+                        val antallÅr: Long = if (utvidet) 13 else 3
                         val requestBody =
                             RequestBody(
                                 ident = personIdent.value,

--- a/src/main/kotlin/no/nav/persondataapi/pensjonsgivendeInntekt/PensjonsgivendeInntektService.kt
+++ b/src/main/kotlin/no/nav/persondataapi/pensjonsgivendeInntekt/PensjonsgivendeInntektService.kt
@@ -38,7 +38,7 @@ class PensjonsgivendeInntektService(
         utvidet: Boolean = false,
     ): PensjonsgivendeInntektResultat =
         coroutineScope {
-            val antallÅr = if (utvidet) 10 else 3
+            val antallÅr = if (utvidet) 13 else 3
             val årListe = HistoriskeÅrService().hentTidligereÅrEkskludertNåværende(antallÅr)
             val deferred =
                 årListe.map { aar ->

--- a/src/main/kotlin/no/nav/persondataapi/service/InntektService.kt
+++ b/src/main/kotlin/no/nav/persondataapi/service/InntektService.kt
@@ -27,7 +27,7 @@ class InntektService(
     ): InntektResultat {
         val kontrollperiode =
             KontrollPeriode(
-                LocalDate.now().minusYears(if (utvidet) 10 else 5),
+                LocalDate.now().minusYears(if (utvidet) 13 else 5),
                 LocalDate.now(),
             )
         // Hent inntekter fra InntektClient

--- a/src/test/kotlin/no/nav/persondataapi/pensjonsgivendeInntekt/SisteXÅrServiceTest.kt
+++ b/src/test/kotlin/no/nav/persondataapi/pensjonsgivendeInntekt/SisteXÅrServiceTest.kt
@@ -25,4 +25,13 @@ class `SisteXÅrServiceTest` {
         Assertions.assertFalse(response.contains(detteÅret))
         println(response)
     }
+
+    @Test
+    fun skalKunneHenteUt13År() {
+        val detteÅret = Year.now().value
+        val response = HistoriskeÅrService().hentTidligereÅrEkskludertNåværende(13)
+        Assertions.assertNotNull(response)
+        Assertions.assertTrue(response.contains(detteÅret - 13))
+        Assertions.assertFalse(response.contains(detteÅret))
+    }
 }

--- a/src/test/kotlin/no/nav/persondataapi/service/InntektServiceTest.kt
+++ b/src/test/kotlin/no/nav/persondataapi/service/InntektServiceTest.kt
@@ -2,6 +2,7 @@ package no.nav.persondataapi.service
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import kotlinx.coroutines.runBlocking
 import no.nav.inntekt.generated.model.HistorikkData
 import no.nav.inntekt.generated.model.InntektshistorikkApiUt
@@ -14,6 +15,7 @@ import no.nav.persondataapi.integrasjon.ereg.client.PeriodeDato
 import no.nav.persondataapi.integrasjon.ereg.client.PeriodeTid
 import no.nav.persondataapi.integrasjon.inntekt.client.InntektClient
 import no.nav.persondataapi.integrasjon.inntekt.client.InntektDataResultat
+import no.nav.persondataapi.integrasjon.inntekt.client.KontrollPeriode
 import no.nav.persondataapi.konfigurasjon.JsonUtils
 import no.nav.persondataapi.rest.domene.PersonIdent
 import org.junit.jupiter.api.Assertions
@@ -397,6 +399,29 @@ class InntektServiceTest {
             assertEquals(2, data.lønnsinntekt.size)
             assertEquals("2024-01", data.lønnsinntekt[0].periode)
             assertEquals("2024-02", data.lønnsinntekt[1].periode)
+        }
+
+    @Test
+    fun `skal bruke 13 år som startdato når utvidet er true`() =
+        runBlocking {
+            val brukertilgangService = mockk<BrukertilgangService>()
+            val inntektClient = mockk<InntektClient>()
+            val eregClient = mockk<EregClient>()
+            val periodSlot = slot<KontrollPeriode>()
+
+            every { brukertilgangService.harSaksbehandlerTilgangTilPersonIdent(any()) } returns true
+            every { inntektClient.hentInntekter(any(), capture(periodSlot)) } returns
+                InntektDataResultat(
+                    data = InntektshistorikkApiUt(data = emptyList()),
+                    statusCode = 200,
+                    errorMessage = null,
+                )
+            every { eregClient.hentOrganisasjon(any()) } returns lagEregRespons("999888777", "Test Bedrift AS")
+
+            val service = InntektService(inntektClient, eregClient, brukertilgangService)
+            service.hentInntekterForPerson(PersonIdent("12345678901"), utvidet = true)
+
+            assertEquals(LocalDate.now().minusYears(13), periodSlot.captured.fom)
         }
 }
 

--- a/src/test/kotlin/no/nav/persondataapi/test/LocalWireMockSmokeTest.kt
+++ b/src/test/kotlin/no/nav/persondataapi/test/LocalWireMockSmokeTest.kt
@@ -4,7 +4,9 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import kotlinx.coroutines.runBlocking
+import no.nav.persondataapi.integrasjon.aap.meldekort.client.AapClient
 import no.nav.persondataapi.integrasjon.aareg.client.AaregClient
+import no.nav.persondataapi.integrasjon.dagpenger.datadeling.DagpengerDatadelingClient
 import no.nav.persondataapi.integrasjon.inntekt.client.InntektClient
 import no.nav.persondataapi.integrasjon.kodeverk.client.KodeverkClient
 import no.nav.persondataapi.integrasjon.modiacontextholder.client.ModiaContextHolderClient
@@ -12,10 +14,12 @@ import no.nav.persondataapi.integrasjon.nom.NomClient
 import no.nav.persondataapi.integrasjon.pdl.client.PdlClient
 import no.nav.persondataapi.integrasjon.tilgangsmaskin.client.TilgangsmaskinClientImpl
 import no.nav.persondataapi.integrasjon.utbetaling.client.UtbetalingClient
+import no.nav.persondataapi.pensjonsgivendeInntekt.PensjonsgivendeInntektService
 import no.nav.persondataapi.rest.domene.PersonIdent
 import no.nav.security.token.support.core.context.TokenValidationContext
 import no.nav.security.token.support.core.context.TokenValidationContextHolder
 import no.nav.security.token.support.core.jwt.JwtToken
+import no.nav.security.token.support.core.jwt.JwtTokenClaims
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -88,6 +92,15 @@ class LocalWireMockSmokeTest {
     @Autowired
     lateinit var nomClient: NomClient
 
+    @Autowired
+    lateinit var aapClient: AapClient
+
+    @Autowired
+    lateinit var dagpengerDatadelingClient: DagpengerDatadelingClient
+
+    @Autowired
+    lateinit var pensjonsgivendeInntektService: PensjonsgivendeInntektService
+
     @MockitoBean
     lateinit var tokenValidationContextHolder: TokenValidationContextHolder
 
@@ -95,7 +108,9 @@ class LocalWireMockSmokeTest {
     fun settOppBrukertoken() {
         val context = mock(TokenValidationContext::class.java)
         val token = mock(JwtToken::class.java)
+        val claims = mock(JwtTokenClaims::class.java)
         given(token.encodedToken).willReturn("test-bruker-token")
+        given(token.jwtTokenClaims).willReturn(claims)
         given(context.firstValidToken).willReturn(token)
         given(tokenValidationContextHolder.getTokenValidationContext()).willReturn(context)
     }
@@ -192,5 +207,27 @@ class LocalWireMockSmokeTest {
                     .urlPathEqualTo("/api/v1/token/exchange"),
             ),
         )
+    }
+
+    @Test
+    fun `utvidet tidsvindu kaller klienter med 13 ar`() {
+        val personIdent = PersonIdent("12345678901")
+
+        val aapResultat = aapClient.hentAapMax(personIdent, utvidet = true)
+        val dagpengerResultat = dagpengerDatadelingClient.hentDagpengeMeldekort(personIdent, utvidet = true)
+        val utbetalingResultat = utbetalingClient.hentUtbetalingerForBruker(personIdent, utvidet = true)
+
+        assertTrue(aapResultat.statusCode == 200 || aapResultat.statusCode == 404)
+        assertTrue(dagpengerResultat.statusCode == 200 || dagpengerResultat.statusCode == 404)
+        assertTrue(utbetalingResultat.statusCode == 200 || utbetalingResultat.statusCode == 404)
+
+        runBlocking {
+            val pensjonsresultat =
+                pensjonsgivendeInntektService.hentPensjonsgivendeInntektForPerson(personIdent, utvidet = true)
+            assertTrue(
+                pensjonsresultat is PensjonsgivendeInntektService.PensjonsgivendeInntektResultat.Success ||
+                    pensjonsresultat is PensjonsgivendeInntektService.PensjonsgivendeInntektResultat.PersonIkkeFunnet,
+            )
+        }
     }
 }


### PR DESCRIPTION
Denne PR-en utvider tidsvinduet for `utvidet=true` fra 10 til 13 år i backend, som følge av at watson-sok har fått en ny «13 år»-knapp (bak feature flag `watson-sok-v-1-2`).

## Hva er endret

Alle steder som returnerer tidsvindu basert på `utvidet`-parameteren er oppdatert fra 10 → 13 år:

- `DagpengerDatadelingClient.kt` — `antallÅr: Long = if (utvidet) 13 else 3`
- `AapClient.kt` — `antallÅr: Long = if (utvidet) 13 else 3`
- `UtbetalingClient.kt` — `antallÅr: Long = if (utvidet) 13 else 3`
- `InntektService.kt` — `minusYears(if (utvidet) 13 else 5)`
- `PensjonsgivendeInntektService.kt` — `antallÅr = if (utvidet) 13 else 3`

`InntektClient.kt` linje 43 (`minusYears(5)`) er **ikke** endret — den er ikke styrt av `utvidet`-parameteren.

## Tester

Lagt til `skalKunneHenteUt13År` i `SisteXÅrServiceTest` for å verifisere at `HistoriskeÅrService` håndterer 13 år korrekt.

## Verifiser

- [ ] At `?utvidet=true` nå returnerer data for inntil 13 år tilbake
- [ ] At `?utvidet=false` (3 eller 5 år) er uendret
- [ ] At watson-sok med feature flag `watson-sok-v-1-2` viser korrekt data for «13 år»-knappen